### PR TITLE
Scale SpeX spectra

### DIFF
--- a/measure_extinction/extdata.py
+++ b/measure_extinction/extdata.py
@@ -675,7 +675,7 @@ class ExtData:
         Returns
         -------
         ptype : string
-            Latex formated string for plotting
+            Latex formatted string for plotting
         """
         if not ytype:
             ytype = self.type

--- a/measure_extinction/stardata.py
+++ b/measure_extinction/stardata.py
@@ -695,7 +695,7 @@ class SpecData:
         self.read_spectra(line, path)
 
         # correct the SpeX spectra if desired and if corfacs are defined
-        if use_corfac==True and "SpeX" in corfac.keys():
+        if use_corfac and "SpeX" in corfac.keys():
             self.fluxes *= corfac["SpeX"]
             self.uncs *= corfac["SpeX"]
 
@@ -737,7 +737,7 @@ class SpecData:
         # self.uncs *= mfac
 
         # correct the IRS spectra if desired and if corfacs are defined
-        if use_corfac==True and "IRS" in corfac.keys():
+        if use_corfac and "IRS" in corfac.keys():
             if ("IRS_zerowave" in corfac.keys()) and ("IRS_slope" in corfac.keys()):
                 mod_line = corfac["IRS"] + (
                     corfac["IRS_slope"] * (self.waves.value - corfac["IRS_zerowave"])

--- a/measure_extinction/utils/make_obsdata_from_model.py
+++ b/measure_extinction/utils/make_obsdata_from_model.py
@@ -103,7 +103,7 @@ def get_phot(mwave, mflux, band_names, band_resp_filenames):
         model fluxes
 
     band_names: list of strings
-        names of bands reqeusted
+        names of bands requested
 
     band_resp_filename : list of strings
         filenames of band response functions for the requested bands

--- a/measure_extinction/utils/make_obsdata_from_model.py
+++ b/measure_extinction/utils/make_obsdata_from_model.py
@@ -112,7 +112,7 @@ def get_phot(mwave, mflux, band_names, band_resp_filenames):
     -------
     bandinfo : BandData object
     """
-    # get a band data object
+    # get a BandData object
     bdata = BandData("BAND")
 
     # path for non-HST band response curves

--- a/measure_extinction/utils/spex_corr.py
+++ b/measure_extinction/utils/spex_corr.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+
+import argparse
+import numpy as np
+import astropy.units as u
+import pkg_resources
+
+from astropy.table import Table
+from synphot import SpectralElement
+from measure_extinction.stardata import StarData
+from measure_extinction.stardata import BandData
+
+# function to get photometry from a spectrum
+def get_phot(wave, flux, band_names, band_resp_filenames):
+    """
+    Compute the fluxes in the requested bands.
+
+    Parameters
+    ----------
+    wave : vector
+        spectrum wavelengths
+
+    flux : vector
+        spectrum fluxes
+
+    band_names: list of strings
+        names of bands requested
+
+    band_resp_filename : list of strings
+        filenames of band response functions for the requested bands
+
+    Outputs
+    -------
+    band fluxes : dict of {band: flux}
+    """
+
+    # create a BandData object
+    bdata = BandData("BAND")
+
+    # path for band response curves
+    band_path = pkg_resources.resource_filename(
+        "measure_extinction", "data/Band_RespCurves/"
+    )
+
+    # compute the fluxes in each band
+    for k, band in enumerate(band_names):
+        bp = SpectralElement.from_file("%s%s" % (band_path, band_resp_filenames[k]))
+        resp = bp(wave)
+        bflux = np.sum(resp * flux) / np.sum(resp)
+        bflux_unc = 0.0
+        bdata.band_fluxes[band] = (bflux, bflux_unc)
+
+    return bdata.band_fluxes
+
+# function to compare the photometry obtained from the spectrum with the band photometry
+# and to calculate a correction factor
+def calc_corfac(fluxes_bands, fluxes_spectra, band):
+    return fluxes_bands[band][0] / fluxes_spectra[band][0]
+
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument("starname", help="name of the star (filebase)")
+    parser.add_argument("--path", help="path where data files are stored",
+    default=pkg_resources.resource_filename('measure_extinction',
+                                            'data/'))
+
+    args = parser.parse_args()
+
+    # read in the data file (do not use the correction factors at this point)
+    star_data = StarData('%s.dat' % args.starname.lower(), path=args.path, use_corfac=False)
+    star_phot = star_data.data["BAND"]
+    star_spec = star_data.data["SpeX"]
+
+    # get the band photometry and the photometry from the spectrum
+    fluxes_bands = star_phot.band_fluxes
+    fluxes_spectra = get_phot(star_spec.waves.to(u.Angstrom), star_spec.fluxes.value, ["J","H","K"], ["JohnJ.dat","JohnH.dat","JohnK.dat"])
+
+    # compute the correction factors for the different bands and average them
+    corfac_J = calc_corfac(fluxes_bands, fluxes_spectra, "J")
+    corfac_H = calc_corfac(fluxes_bands, fluxes_spectra, "H")
+    corfac_K = calc_corfac(fluxes_bands, fluxes_spectra, "K")
+    av_corfac = np.mean([corfac_J, corfac_H, corfac_K])
+
+    # add this correction factor to the data file if it is not already in there,
+    # otherwise overwrite the existing correction factor
+    if "SpeX" in star_data.corfac.keys():
+        datafile = open(args.path+'%s.dat' % args.starname.lower(), "w")
+        for ln, line in enumerate(star_data.datfile_lines):
+            if "corfac_spex" in line:
+                line = "corfac_spex = " + str(av_corfac) + "\n"
+            datafile.write(line)
+        datafile.close()
+    else:
+         with open(args.path+'%s.dat' % args.starname.lower(), "a") as datafile:
+             datafile.write("corfac_spex = "+ str(av_corfac) + "\n")


### PR DESCRIPTION
Hi,

I wrote code to calculate the scaling factor for the SpeX spectra, based on JHK photometry. It is calculating the mean of the 3 factors, and writing it to the .dat file. If there is already a spex correction factor in the .dat file, it will be overwritten. The way in which I coded the latter looks a bit cumbersome to me, so let me know if you have an idea to make this part better.

The "NaN" problem in the sum is not a problem anymore as StarData automatically replaces NaN values in the spectrum by 0s when reading in the spectrum.

I will add more stuff to do the scaling of the SXD and LXD separately, but need to "split" the spectra first.
Any suggestions/corrections are very welcome!

Marjorie