### PR TITLE
Dereddening for standards

### DIFF
--- a/measure_extinction/extdata.py
+++ b/measure_extinction/extdata.py
@@ -1157,9 +1157,7 @@ class ExtData:
             if curtype in exclude:
                 continue
             # replace extinction values by NaNs for wavelength regions that need to be excluded from the plot
-            bdata = self.npts[curtype] == 0
-            if np.any(bdata):
-                self.exts[curtype][bdata] = np.nan
+            self.exts[curtype][self.npts[curtype] == 0] = np.nan
             x = self.waves[curtype].to(u.micron).value
             y = self.exts[curtype]
             yu = self.uncs[curtype]

--- a/measure_extinction/extdata.py
+++ b/measure_extinction/extdata.py
@@ -1157,7 +1157,9 @@ class ExtData:
             if curtype in exclude:
                 continue
             # replace extinction values by NaNs for wavelength regions that need to be excluded from the plot
-            self.exts[curtype][self.npts[curtype] == 0] = np.nan
+            bdata = self.npts[curtype] == 0
+            if np.any(bdata):
+                self.exts[curtype][bdata] = np.nan
             x = self.waves[curtype].to(u.micron).value
             y = self.exts[curtype]
             yu = self.uncs[curtype]
@@ -1189,8 +1191,6 @@ class ExtData:
                 ann_val += (annotate_yoffset,)
                 ann_xval = 0.5 * np.sum(annotate_wave_range.value)
 
-                if wavenum:
-                    ann_xval = 1.0 / ann_xval
                 pltax.text(
                     ann_xval,
                     ann_val,

--- a/measure_extinction/extdata.py
+++ b/measure_extinction/extdata.py
@@ -1188,6 +1188,9 @@ class ExtData:
                 ann_val = np.nanmedian(y[ann_indxs])
                 ann_val += (annotate_yoffset,)
                 ann_xval = 0.5 * np.sum(annotate_wave_range.value)
+
+                if wavenum:
+                    ann_xval = 1.0 / ann_xval
                 pltax.text(
                     ann_xval,
                     ann_val,

--- a/measure_extinction/plotting/plot_ext.py
+++ b/measure_extinction/plotting/plot_ext.py
@@ -664,7 +664,7 @@ def plot_extinction(
         plt.show()
 
 
-if __name__ == "__main__":
+def main():
     # commandline parser
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -747,3 +747,7 @@ if __name__ == "__main__":
                 args.exclude,
                 args.pdf,
             )
+
+
+if __name__ == "__main__":
+    main()

--- a/measure_extinction/plotting/plot_spec.py
+++ b/measure_extinction/plotting/plot_spec.py
@@ -340,7 +340,6 @@ def plot_spectrum(
     if norm_range is not None:
         norm_range = norm_range * u.micron
     starobs.plot(ax, norm_wave_range=norm_range, mlam4=mlam4, exclude=exclude)
-
     # plot HI-lines if requested
     if HI_lines:
         plot_HI(path, ax)

--- a/measure_extinction/plotting/plot_spec.py
+++ b/measure_extinction/plotting/plot_spec.py
@@ -286,6 +286,8 @@ def plot_spectrum(
     range=None,
     norm_range=None,
     exclude=[],
+    log=False,
+    wavenum=False,
     pdf=False,
 ):
     """
@@ -306,13 +308,19 @@ def plot_spectrum(
         Whether or not to indicate the HI-lines in the plot
 
     range : list of 2 floats [default=None]
-        Wavelength range to be plotted (in micron) - [min,max]
+        Wavelength range to be plotted - [min,max]
 
     norm_range : list of 2 floats [default=None]
         Wavelength range to use to normalize the data (in micron)- [min,max]
 
     exclude : list of strings [default=[]]
         List of data type(s) to exclude from the plot (e.g., IRS)
+
+    log : boolean [default=False]
+        Whether or not to plot the wavelengths on a log-scale
+
+    wavenum : boolean [default=False]
+        Whether or not to plot the wavelengths as wavenumbers = 1/wavelength
 
     pdf : boolean [default=False]
         Whether or not to save the figure as a pdf file
@@ -339,7 +347,8 @@ def plot_spectrum(
     starobs = StarData("%s.dat" % star.lower(), path=path, use_corfac=True)
     if norm_range is not None:
         norm_range = norm_range * u.micron
-    starobs.plot(ax, norm_wave_range=norm_range, mlam4=mlam4, exclude=exclude)
+    starobs.plot(ax, norm_wave_range=norm_range, mlam4=mlam4, exclude=exclude,
+                 wavenum=wavenum)
     # plot HI-lines if requested
     if HI_lines:
         plot_HI(path, ax)
@@ -353,10 +362,15 @@ def plot_spectrum(
         outname = outname.replace(".pdf", "_zoom.pdf")
 
     # finish configuring the plot
-    ax.set_xscale("log")
+    if log:
+        ax.set_xscale("log")
     ax.set_yscale("log")
     ax.set_title(star.upper(), fontsize=50)
-    ax.set_xlabel(r"$\lambda$ [$\mu m$]", fontsize=1.5 * fontsize)
+    if wavenum:
+        xlab = r"$1/\lambda$ [$\mu m^{-1}$]"
+    else:
+        xlab = r"$\lambda$ [$\mu m$]"
+    ax.set_xlabel(xlab, fontsize=1.5 * fontsize)
     if mlam4:
         ax.set_ylabel(
             r"$F(\lambda)\ \lambda^4$ [$ergs\ cm^{-2}\ s^{-1}\ \AA^{-1}\ \mu m^4$]",
@@ -402,7 +416,7 @@ def main():
     parser.add_argument(
         "--range",
         nargs="+",
-        help="wavelength range to be plotted (in micron)",
+        help="wavelength range to be plotted",
         type=float,
         default=None,
     )
@@ -427,6 +441,9 @@ def main():
     )
     parser.add_argument(
         "--log", help="plot wavelengths on a log-scale", action="store_true"
+    )
+    parser.add_argument(
+        "--wavenum", help="plot wavenumbers = 1/wavelengths", action="store_true"
     )
     parser.add_argument("--pdf", help="save figure as a pdf file", action="store_true")
     args = parser.parse_args()
@@ -459,9 +476,9 @@ def main():
                 args.norm_range,
                 args.exclude,
                 args.log,
+                args.wavenum,
                 args.pdf,
             )
-
 
 
 if __name__ == "__main__":

--- a/measure_extinction/plotting/plot_spec.py
+++ b/measure_extinction/plotting/plot_spec.py
@@ -379,7 +379,7 @@ def plot_spectrum(
         plt.show()
 
 
-if __name__ == "__main__":
+def main():
     # commandline parser
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -461,3 +461,8 @@ if __name__ == "__main__":
                 args.log,
                 args.pdf,
             )
+
+
+
+if __name__ == "__main__":
+    main()

--- a/measure_extinction/plotting/plot_spec.py
+++ b/measure_extinction/plotting/plot_spec.py
@@ -105,6 +105,8 @@ def plot_multi_spectra(
     class_offset=True,
     text_offsets=[],
     text_angles=[],
+    wavenum=False,
+    deredden=False,
     pdf=False,
     outname="all_spec.pdf",
 ):
@@ -152,6 +154,13 @@ def plot_multi_spectra(
     pdf : boolean [default=False]
         Whether or not to save the figure as a pdf file
 
+    wavenum : boolean [default=False]
+        Whether or not to plot the wavelengths as wavenumbers = 1/wavelength
+
+    deredden : boolean [default=False]
+       Deredden the data based on dereddening parameters given in the DAT file.
+       Generally used to deredden standards.
+
     outname : string [default="all_spec.pdf"]
         Name for the output pdf file
 
@@ -185,7 +194,9 @@ def plot_multi_spectra(
 
     for i, star in enumerate(starlist):
         # read in all bands and spectra for this star
-        starobs = StarData("%s.dat" % star.lower(), path=path, use_corfac=True)
+        starobs = StarData(
+            "%s.dat" % star.lower(), path=path, use_corfac=True, deredden=deredden
+        )
 
         # spread out the spectra if requested
         # add extra whitespace when the luminosity class changes from main sequence to giant
@@ -205,17 +216,25 @@ def plot_multi_spectra(
         (waves, fluxes, flux_uncs) = starobs.get_flat_data_arrays(
             starobs.data.keys() - (exclude + exclude2)
         )
+        if wavenum:
+            x = 1 / waves
+        else:
+            x = waves
         if range is not None:
-            waves = waves[waves >= range[0]]
-        min_wave = waves[0]
+            x = x[x >= range[0]]
+        min_x = x[0]
         # find out which data type corresponds with this wavelength
         for data_type in starobs.data.keys():
             if data_type in exclude:
                 continue
-            used_waves = starobs.data[data_type].waves[starobs.data[data_type].npts > 0]
-            if min_wave in used_waves.value:
+            if wavenum:
+                cx = 1.0 / starobs.data[data_type].waves
+            else:
+                cx = starobs.data[data_type].waves
+            used_x = cx[starobs.data[data_type].npts > 0]
+            if min_x in used_x.value:
                 ann_key = data_type
-        ann_range = [min_wave, min_wave] * u.micron
+        ann_range = [min_x, min_x] * u.micron
 
         # plot the spectrum
         starobs.plot(
@@ -223,6 +242,7 @@ def plot_multi_spectra(
             pcolor=colors(i % 10),
             norm_wave_range=norm_range,
             mlam4=mlam4,
+            wavenum=wavenum,
             exclude=exclude,
             yoffset=yoffset,
             yoffset_type="add",
@@ -248,7 +268,11 @@ def plot_multi_spectra(
         ax.set_yscale("log")
     if log:
         ax.set_xscale("log")
-    ax.set_xlabel(r"$\lambda$ [$\mu m$]", fontsize=1.5 * fontsize)
+    if wavenum:
+        xlab = r"$1/\lambda$ [$\mu m^{-1}$]"
+    else:
+        xlab = r"$\lambda$ [$\mu m$]"
+    ax.set_xlabel(xlab, fontsize=1.5 * fontsize)
     ylabel = r"$F(\lambda)$"
 
     if norm_range is not None:
@@ -288,6 +312,7 @@ def plot_spectrum(
     exclude=[],
     log=False,
     wavenum=False,
+    deredden=False,
     pdf=False,
 ):
     """
@@ -322,6 +347,10 @@ def plot_spectrum(
     wavenum : boolean [default=False]
         Whether or not to plot the wavelengths as wavenumbers = 1/wavelength
 
+    deredden : boolean [default=False]
+       Deredden the data based on dereddening parameters given in the DAT file.
+       Generally used to deredden standards.
+
     pdf : boolean [default=False]
         Whether or not to save the figure as a pdf file
 
@@ -344,11 +373,14 @@ def plot_spectrum(
     fig, ax = plt.subplots(figsize=(13, 10))
 
     # read in and plot all bands and spectra for this star
-    starobs = StarData("%s.dat" % star.lower(), path=path, use_corfac=True)
+    starobs = StarData(
+        "%s.dat" % star.lower(), path=path, use_corfac=True, deredden=deredden
+    )
     if norm_range is not None:
         norm_range = norm_range * u.micron
-    starobs.plot(ax, norm_wave_range=norm_range, mlam4=mlam4, exclude=exclude,
-                 wavenum=wavenum)
+    starobs.plot(
+        ax, norm_wave_range=norm_range, mlam4=mlam4, exclude=exclude, wavenum=wavenum
+    )
     # plot HI-lines if requested
     if HI_lines:
         plot_HI(path, ax)
@@ -445,6 +477,11 @@ def main():
     parser.add_argument(
         "--wavenum", help="plot wavenumbers = 1/wavelengths", action="store_true"
     )
+    parser.add_argument(
+        "--deredden",
+        help="deredden the data based on saved parameters",
+        action="store_true",
+    )
     parser.add_argument("--pdf", help="save figure as a pdf file", action="store_true")
     args = parser.parse_args()
 
@@ -459,6 +496,8 @@ def main():
             spread=args.spread,
             exclude=args.exclude,
             log=args.log,
+            wavenum=args.wavenum,
+            deredden=args.deredden,
             pdf=args.pdf,
         )
     else:  # plot all spectra separately
@@ -470,14 +509,15 @@ def main():
             plot_spectrum(
                 star,
                 args.path,
-                args.mlam4,
-                args.HI_lines,
-                args.range,
-                args.norm_range,
-                args.exclude,
-                args.log,
-                args.wavenum,
-                args.pdf,
+                mlam4=args.mlam4,
+                HI_lines=args.HI_lines,
+                range=args.range,
+                norm_range=args.norm_range,
+                exclude=args.exclude,
+                log=args.log,
+                wavenum=args.wavenum,
+                deredden=args.deredden,
+                pdf=args.pdf,
             )
 
 

--- a/measure_extinction/plotting/plot_spec.py
+++ b/measure_extinction/plotting/plot_spec.py
@@ -66,7 +66,8 @@ def zoom(ax, range):
         Axes of plot for which new limits need to be set
 
     range : list of 2 floats
-        Wavelength range to be plotted (in micron) - [min,max]
+        Wavelength range to be plotted [min, max]
+        in micron when plotting wavelengths or in 1/micron when plotting wavenumber
 
     Returns
     -------
@@ -128,7 +129,8 @@ def plot_multi_spectra(
         Whether or not to indicate the HI-lines in the plot
 
     range : list of 2 floats [default=None]
-        Wavelength range to be plotted (in micron) - [min,max]
+        Wavelength range to be plotted [min, max]
+        in micron when plotting wavelengths or in 1/micron when plotting wavenumber
 
     norm_range : list of 2 floats [default=None]
         Wavelength range to use to normalize the data (in micron)- [min,max]

--- a/measure_extinction/stardata.py
+++ b/measure_extinction/stardata.py
@@ -1314,6 +1314,6 @@ class StarData:
                     ann_val,
                     annotate_text,
                     color=annotate_color,
-                    horizontalalignment="left",
+                    horizontalalignment="center",
                     rotation=annotate_rotation,
                 )

--- a/measure_extinction/stardata.py
+++ b/measure_extinction/stardata.py
@@ -987,6 +987,7 @@ class StarData:
                         )
                     else:
                         warnings.warn(f"{fname} does not exist", UserWarning)
+        # self.deredden()
 
     @staticmethod
     def _parse_dfile_line(line):
@@ -1125,6 +1126,7 @@ class StarData:
         pcolor=None,
         norm_wave_range=None,
         mlam4=False,
+        wavenum=False,
         exclude=[],
         yoffset=None,
         yoffset_type="multiply",
@@ -1152,6 +1154,9 @@ class StarData:
 
         mlam4 : boolean [default=False]
             plot the data multiplied by lambda^4 to remove the Rayleigh-Jeans slope
+
+        wavenum : boolean [default=False]
+            plot x axis as 1/wavelength as is standard for UV extinction curves
 
         exclude : list of strings [default=[]]
             Which data type(s) to exclude from the plot (e.g., IRS)
@@ -1243,6 +1248,11 @@ class StarData:
             # do not plot the excluded data type(s)
             if curtype in exclude:
                 continue
+
+            x = self.data[curtype].waves.value
+            if wavenum:
+                x = 1.0 / x
+
             # replace fluxes by NaNs for wavelength regions that need to be excluded from the plot, to avoid separate regions being connected artificially
             self.data[curtype].fluxes[self.data[curtype].npts == 0] = np.nan
             if mlam4:
@@ -1282,7 +1292,7 @@ class StarData:
             if curtype == "BAND":
                 # plot band data as points with errorbars
                 ax.errorbar(
-                    self.data[curtype].waves.value,
+                    x,
                     yplotvals,
                     yerr=ymult * yuncs,
                     fmt="o",
@@ -1292,7 +1302,7 @@ class StarData:
                 )
             else:
                 ax.plot(
-                    self.data[curtype].waves.value,
+                    x,
                     yplotvals,
                     "-",
                     color=pcolor,
@@ -1309,6 +1319,8 @@ class StarData:
                 ann_val = np.nanmedian(yplotvals[ann_indxs])
                 ann_val += (annotate_yoffset,)
                 ann_xval = 0.5 * np.sum(annotate_wave_range.value)
+                if wavenum:
+                    ann_xval = 1 / ann_xval
                 ax.text(
                     ann_xval,
                     ann_val,

--- a/measure_extinction/stardata.py
+++ b/measure_extinction/stardata.py
@@ -1075,7 +1075,7 @@ class StarData:
                     warnings.warn(f"{curtype} cannot be dereddened", UserWarning)
         else:
             warnings.warn(
-                "cannont deredden as no dereddening parameters set", UserWarning
+                "cannot deredden as no dereddening parameters set", UserWarning
             )
 
     def get_flat_data_arrays(self, req_datasources):

--- a/measure_extinction/stardata.py
+++ b/measure_extinction/stardata.py
@@ -1316,4 +1316,5 @@ class StarData:
                     color=annotate_color,
                     horizontalalignment="center",
                     rotation=annotate_rotation,
+                    fontsize=fontsize,
                 )

--- a/measure_extinction/tests/test_calc_ext.py
+++ b/measure_extinction/tests/test_calc_ext.py
@@ -12,7 +12,7 @@ def test_calc_extinction():
     compstarname = "HD204172"
 
     # calculate the extinction curve
-    calc_extinction(redstarname, compstarname, data_path)
+    calc_extinction(redstarname, compstarname, data_path, savepath=data_path)
 
     # check if an extinction curve has been calculated and saved to a fits file
     assert os.path.isfile(

--- a/measure_extinction/utils/calc_ext.py
+++ b/measure_extinction/utils/calc_ext.py
@@ -9,16 +9,16 @@ from measure_extinction.stardata import StarData
 from measure_extinction.extdata import ExtData, AverageExtData
 
 
-def calc_extinction(redstarname, compstarname, path):
+def calc_extinction(redstarname, compstarname, path, savepath="./", deredden=False):
     # read in the observed data for both stars
     redstarobs = StarData("%s.dat" % redstarname.lower(), path=path)
-    compstarobs = StarData("%s.dat" % compstarname.lower(), path=path)
+    compstarobs = StarData("%s.dat" % compstarname.lower(), path=path, deredden=deredden)
 
     # calculate the extinction curve
     extdata = ExtData()
     extdata.calc_elx(redstarobs, compstarobs)
 
-    extdata.save(path + "%s_%s_ext.fits" % (redstarname.lower(), compstarname.lower()))
+    extdata.save(savepath + "%s_%s_ext.fits" % (redstarname.lower(), compstarname.lower()))
 
 
 def calc_ave_ext(starpair_list, path, min_number=1):
@@ -40,9 +40,16 @@ def main():
         help="path to data files",
         default=pkg_resources.resource_filename("measure_extinction", "data/"),
     )
+    parser.add_argument(
+        "--deredden",
+        help="deredden standard based on DAT file dered parameters",
+        action="store_true",
+    )
     args = parser.parse_args()
 
-    calc_extinction(args.redstarname, args.compstarname, args.path)
+    calc_extinction(
+        args.redstarname, args.compstarname, args.path, deredden=args.deredden
+    )
 
 
 if __name__ == "__main__":

--- a/measure_extinction/utils/calc_ext.py
+++ b/measure_extinction/utils/calc_ext.py
@@ -30,8 +30,7 @@ def calc_ave_ext(starpair_list, path, min_number=1):
     average.save(path + "average_ext.fits")
 
 
-if __name__ == "__main__":
-
+def main():
     # commandline parser
     parser = argparse.ArgumentParser()
     parser.add_argument("redstarname", help="name of reddened star")
@@ -44,3 +43,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     calc_extinction(args.redstarname, args.compstarname, args.path)
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,6 +44,11 @@ norecursedirs =
     measure_extinction/docs/_build/*
     measure_extinction/docs/api/*
 
+[options.entry_points]
+console_scripts =
+    meplot_spec = measure_extinction.plotting.plot_spec:main
+    meplot_ext = measure_extinction.plotting.plot_ext:main
+
 [coverage:run]
 omit =
     measure_extinction/_astropy_init*

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,6 +48,7 @@ norecursedirs =
 console_scripts =
     meplot_spec = measure_extinction.plotting.plot_spec:main
     meplot_ext = measure_extinction.plotting.plot_ext:main
+    mecalc_ext = measure_extinction.utils.calc_ext:main
 
 [coverage:run]
 omit =


### PR DESCRIPTION
Add the capability to deredden star data based on FM90+CCM89 parameters.  This supports Milky Way UV extinction curve work where dereddening the standards is needed and has been a common technique for many years (see https://ui.adsabs.harvard.edu/abs/1992AJ....104.1916C/abstract).   For the MW standards, the necessary dereddening info is saved in the dat files.

Also added entry-points (aka system wide aliases) for meplot_spec, meplot_ext, and mecalc_ext that correspond to running the plotting/plot_spec, plotting/plot_ext, and utils/calc_ext scripts.