### PR TITLE
Add wavenum plot option

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -59,9 +59,9 @@ contributors who will abide by the `Python Software Foundation Code of Conduct
 `Astropy`_.  The following pages will help you get started with contributing
 fixes, code, or documentation (no git or GitHub experience necessary):
 
-* `How to make a code contribution <https://docs.astropy.org/en/stable/development/workflow/development_workflow.html>`_
+* `How to make a code contribution <https://docs.astropy.org/en/latest/development/workflow/development_workflow.html>`_
 
-* `Coding Guidelines <https://docs.astropy.org/en/stable/development/codeguide.html>`_
+* `Coding Guidelines <https://docs.astropy.org/en/latest/development/codeguide.html>`_
 
 * `Developer Documentation <https://docs.astropy.org/en/stable/#developer-documentation>`_
 

--- a/measure_extinction/extdata.py
+++ b/measure_extinction/extdata.py
@@ -825,9 +825,10 @@ class ExtData:
                     param.name + " upper uncertainty",
                 )
             tbhdu.header.set("MOD_TYPE", self.model["type"], "Type of fitted model")
-            tbhdu.header.set(
-                "chi2", self.model["chi2"], "Chi squared for the fitted model"
-            )
+            if "chi2" in self.model.keys():
+                tbhdu.header.set(
+                    "chi2", self.model["chi2"], "Chi squared for the fitted model"
+                )
             tbhdu.header.set("EXTNAME", "MODEXT", "Fitted model extinction")
             hdulist.append(tbhdu)
 

--- a/measure_extinction/extdata.py
+++ b/measure_extinction/extdata.py
@@ -1118,9 +1118,7 @@ class ExtData:
             if curtype in exclude:
                 continue
             # replace extinction values by NaNs for wavelength regions that need to be excluded from the plot
-            bdata = self.npts[curtype] == 0
-            if np.any(bdata):
-                self.exts[curtype][bdata] = np.nan
+            self.exts[curtype][self.npts[curtype] == 0] = np.nan
             x = self.waves[curtype].to(u.micron).value
             y = self.exts[curtype]
             yu = self.uncs[curtype]

--- a/measure_extinction/extdata.py
+++ b/measure_extinction/extdata.py
@@ -121,7 +121,7 @@ def AverageExtData(extdatas, min_number=3):
     for extdata in extdatas:
         # check the data type of the extinction curve, and convert if needed
         # the average curve must be calculated from the A(lambda)/A(V) curves
-        if extdata.type != "alav" or extdata.type != "alax":
+        if extdata.type != "alav" and extdata.type != "alax":
             extdata.trans_elv_alav()
 
         # collect the keywords of the data in the extinction curves, and collect the names of the BAND data in the extinction curves, and determine the wavelengths of the data
@@ -135,7 +135,7 @@ def AverageExtData(extdatas, min_number=3):
                         names.append(name)
                         bwaves.append(extdata.waves["BAND"][i].value)
     aveext.names["BAND"] = names
-    aveext.waves["BAND"] = bwaves
+    aveext.waves["BAND"] = bwaves * u.micron
     aveext.type = extdatas[0].type
     aveext.type_rel_band = extdatas[0].type_rel_band
 
@@ -1035,6 +1035,7 @@ class ExtData:
         color=None,
         alpha=None,
         alax=False,
+        wavenum=False,
         exclude=[],
         normval=1.0,
         yoffset=0.0,
@@ -1065,6 +1066,9 @@ class ExtData:
         alax : boolean [default=False]
             convert from E(lambda-X) using A(X), if necessary
             plot A(lambda)/A(X)
+
+        wavenum : boolean [default=False]
+            plot x axis as 1/wavelength as is standard for UV extinction curves
 
         exclude : list of strings [default=[]]
             List of data type(s) to exclude from the plot (e.g., IRS)
@@ -1114,7 +1118,9 @@ class ExtData:
             if curtype in exclude:
                 continue
             # replace extinction values by NaNs for wavelength regions that need to be excluded from the plot
-            self.exts[curtype][self.npts[curtype] == 0] = np.nan
+            bdata = self.npts[curtype] == 0
+            if np.any(bdata):
+                self.exts[curtype][bdata] = np.nan
             x = self.waves[curtype].to(u.micron).value
             y = self.exts[curtype]
             yu = self.uncs[curtype]
@@ -1122,13 +1128,8 @@ class ExtData:
             y = y / normval + yoffset
             yu = yu / normval
 
-            # if curtype == legend_key:
-            #     if legend_label is None:
-            #         legval = self.red_file
-            #     else:
-            #         legval = legend_label
-            # else:
-            #     legval = None
+            if wavenum:
+                x = 1.0 / x
 
             if curtype == "BAND":
                 # plot band data as points with errorbars


### PR DESCRIPTION
Adding `wavenum` option to plotting of extinction curves.  Plotting versus 1/lambda is standard for UV extinction curve work - so useful.

Also have fixed a couple of bugs in the AverageExtData function.