### PR TITLE
Rebinning extinction curves

### DIFF
--- a/measure_extinction/plotting/plot_ext.py
+++ b/measure_extinction/plotting/plot_ext.py
@@ -243,7 +243,7 @@ def plot_fitmodel(extdata, yoffset=0, res=False):
                 extdata.model["params"][2].value,
                 extdata.model["params"][3].value,
             )
-        elif extdata.model["type"] == "pow_alav":
+        elif extdata.model["type"] == "pow_alax":
             labeltxt = r"$%5.3f \,\lambda^{-%5.2f}$" % (
                 extdata.model["params"][0].value,
                 extdata.model["params"][2].value,
@@ -261,7 +261,6 @@ def plot_fitmodel(extdata, yoffset=0, res=False):
             label=labeltxt,
             zorder=5,
         )
-
         plt.legend(loc="lower left")
 
         # plot the residuals if requested

--- a/measure_extinction/plotting/plot_ext.py
+++ b/measure_extinction/plotting/plot_ext.py
@@ -381,6 +381,7 @@ def plot_multi_extinction(
     text_angles=[],
     multicolor=False,
     wavenum=False,
+    figsize=None,
     pdf=False,
 ):
     """
@@ -429,8 +430,12 @@ def plot_multi_extinction(
 
     multicolor : boolean [default=False]
         Whether or not to give all curves a different color
+
     wavenum : boolean [default=False]
         Whether or not to plot the wavelengths as wavenumbers = 1/wavelength
+
+    figsize : tuple [default=None]
+        Tuple with figure size (e.g. (8,15))
 
     pdf : boolean [default=False]
         Whether or not to save the figure as a pdf file
@@ -454,10 +459,9 @@ def plot_multi_extinction(
     plt.rc("ytick", right=True, direction="in", labelsize=fs * 1.1)
 
     # create the plot
-    ysize = 6
-    if spread:
-        ysize += len(starpair_list) * 1.25
-    fig, ax = plt.subplots(figsize=(8, ysize))
+    if figsize is None:
+        figsize = (8, len(starpair_list))
+    fig, ax = plt.subplots(figsize=figsize)
     colors = plt.get_cmap("tab10")
 
     # set default text offsets and angles
@@ -513,7 +517,7 @@ def plot_multi_extinction(
             annotate_text=extdata.red_file.split(".")[0].upper(),
             annotate_yoffset=text_offsets[i],
             annotate_rotation=text_angles[i],
-            annotate_color=colors(i % 10),
+            annotate_color=pcolor,
             wavenum=wavenum,
         )
 
@@ -568,8 +572,6 @@ def plot_multi_extinction(
     if spread:
         ylabel += " + offset"
     ax.set_ylabel(ylabel, fontsize=1.5 * fs)
-
-    fig.tight_layout()
 
     # show the figure or save it to a pdf file
     if pdf:

--- a/measure_extinction/stardata.py
+++ b/measure_extinction/stardata.py
@@ -1149,6 +1149,7 @@ class StarData:
         yoffset_type="multiply",
         annotate_key=None,
         annotate_wave_range=None,
+        annotate_alignment="left",
         annotate_text=None,
         annotate_rotation=0.0,
         annotate_yoffset=0.0,
@@ -1190,11 +1191,14 @@ class StarData:
         annotate_wave_range : list of 2 floats [default=None]
             min/max wavelength range for the annotation of the text
 
+        annotate_alignment : string [default="left"]
+            horizontal alignment of the annotated text ("left", "center", "right")
+
         annotate_text : string [default=None]
             text to annotate
 
         annotate_rotation : float [default=0.0]
-            annotation angle
+            rotation angle of the annotated text
 
         annotate_yoffset : float [default=0.0]
             y-offset for the annotated text
@@ -1347,7 +1351,7 @@ class StarData:
                     ann_val,
                     annotate_text,
                     color=annotate_color,
-                    horizontalalignment="center",
+                    horizontalalignment=annotate_alignment,
                     rotation=annotate_rotation,
                     fontsize=fontsize,
                 )


### PR DESCRIPTION
I changed the way the extinction curves are rebinned.

The original code:
- had a bug related to slicing, see the discussion in issue #87.
- was calculating the mean of the same number of neighboring data points for every "bin". For non-equally spaced wavelength grids, one could thus potentially be taking the mean of values that are very far away.
- returned a nan if any of the values in the bin was nan.

The new code:
- uses a number of equally wide bins and calculates the mean wavelength and mean extinction in every bin. A different number of data points will be used in every bin if the wavelength grid is not equally spaced. This ensure that in sparse regions, not too much binning is happening.
- bins the wavelengths and extinction values at the same time.
- skips nan extinction values and the corresponding wavelengths, so that the same data points are used to calculate the mean wavelength and the mean extinction in a certain bin.

This PR closes #87.