### PR TITLE
Adding the A(V) unc to E(lam-V) to A(lam)/A(V) calculation

### DIFF
--- a/measure_extinction/extdata.py
+++ b/measure_extinction/extdata.py
@@ -557,24 +557,25 @@ class ExtData:
             elif len(np.atleast_1d(fullav)) == 3:
                 fullav = np.array([fullav[0], 0.5 * (fullav[1] + fullav[2])])
             for curname in self.exts.keys():
-                nzvals = self.exts[curname] != 0
+                # special case for the E(lambda - V) = 0 see below
                 zvals = (self.exts[curname] == 0) & (self.npts[curname] > 0)
-                tuncs = np.sqrt(
-                    np.square(self.uncs[curname][nzvals] / self.exts[curname][nzvals])
-                    + np.square(fullav[1] / fullav[0])
+                # formal error propagration where zero extinctions do not
+                # require separate treatment to avoid divide by zero errors
+                self.uncs[curname] = (
+                    np.sqrt(
+                        np.square(self.uncs[curname])
+                        + np.square(self.exts[curname] * fullav[1] / fullav[0])
+                    )
+                    / fullav[0]
                 )
+
                 self.exts[curname] = (self.exts[curname] / fullav[0]) + 1
-                # full/correct error propagration requires mulitplying the
-                # fractional unc by E(lambda-V)/A(V)
-                self.uncs[curname][nzvals] = tuncs * np.absolute(
-                    self.exts[curname][nzvals] - 1.0
-                )
                 # replace the V band uncertainty with the A(V) uncertainty
                 # as this is the only term nominally in the A(lam)/A(V) extinction
                 # that is by definition 1.
                 #  zvals is defined to only be True for V band
                 if np.sum(zvals) > 0:
-                    self.exts[curname][zvals] = fullav[1]
+                    self.uncs[curname][zvals] = fullav[1]
 
             self.type = "alax"
 

--- a/measure_extinction/extdata.py
+++ b/measure_extinction/extdata.py
@@ -554,6 +554,8 @@ class ExtData:
             fullav = self.columns["AV"]
             if len(np.atleast_1d(fullav)) == 1:
                 fullav = np.array([fullav, 0.0])
+            elif len(np.atleast_1d(fullav)) == 3:
+                fullav = np.array([fullav[0], 0.5 * (fullav[1] + fullav[2])])
             for curname in self.exts.keys():
                 tuncs = np.sqrt(
                     np.square(self.uncs[curname] / self.exts[curname])

--- a/measure_extinction/extdata.py
+++ b/measure_extinction/extdata.py
@@ -559,7 +559,7 @@ class ExtData:
             for curname in self.exts.keys():
                 # special case for the E(lambda - V) = 0 see below
                 zvals = (self.exts[curname] == 0) & (self.npts[curname] > 0)
-                # formal error propagration where zero extinctions do not
+                # formal error propagation where zero extinctions do not
                 # require separate treatment to avoid divide by zero errors
                 self.uncs[curname] = (
                     np.sqrt(
@@ -570,12 +570,13 @@ class ExtData:
                 )
 
                 self.exts[curname] = (self.exts[curname] / fullav[0]) + 1
-                # replace the V band uncertainty with the A(V) uncertainty
+                # replace the V band uncertainty with the fractional A(V) uncertainty
                 # as this is the only term nominally in the A(lam)/A(V) extinction
-                # that is by definition 1.
+                # that is by definition 1.  Fractional as the extinction at this
+                # wavelength is normalized to A(V).
                 #  zvals is defined to only be True for V band
                 if np.sum(zvals) > 0:
-                    self.uncs[curname][zvals] = fullav[1]
+                    self.uncs[curname][zvals] = fullav[1] / fullav[0]
 
             self.type = "alax"
 

--- a/measure_extinction/extdata.py
+++ b/measure_extinction/extdata.py
@@ -551,14 +551,15 @@ class ExtData:
             if av is None:
                 if "AV" not in self.columns.keys():
                     self.calc_AV(akav=akav)
-                av = _get_column_val(self.columns["AV"])
             fullav = self.columns["AV"]
+            if len(np.atleast_1d(fullav)) == 1:
+                fullav = np.array([fullav, 0.0])
             for curname in self.exts.keys():
                 tuncs = np.sqrt(
                     np.square(self.uncs[curname] / self.exts[curname])
                     + np.square(fullav[1] / fullav[0])
                 )
-                self.exts[curname] = (self.exts[curname] / av) + 1
+                self.exts[curname] = (self.exts[curname] / fullav[0]) + 1
                 self.uncs[curname] = tuncs * self.exts[curname]
             # update the extinction curve type
             self.type = "alax"

--- a/measure_extinction/extdata.py
+++ b/measure_extinction/extdata.py
@@ -560,7 +560,9 @@ class ExtData:
                     + np.square(fullav[1] / fullav[0])
                 )
                 self.exts[curname] = (self.exts[curname] / fullav[0]) + 1
-                self.uncs[curname] = tuncs * self.exts[curname]
+                # full/correct error propagration requires mulitplying the
+                # fractional unc by E(lambda-V)/A(V)
+                self.uncs[curname] = tuncs * np.absolute(self.exts[curname] - 1.0)
             # update the extinction curve type
             self.type = "alax"
 


### PR DESCRIPTION
Adds in the A(V) uncertainty to the calculation.  Does not usually change the A(lam)/A(V) uncs given the small fractional errors on A(V).  But better to be correct if at all possible.