### PR TITLE
Use flexible output name

### DIFF
--- a/measure_extinction/utils/calc_ext.py
+++ b/measure_extinction/utils/calc_ext.py
@@ -24,13 +24,39 @@ def calc_extinction(redstarname, compstarname, path, savepath="./", deredden=Fal
     )
 
 
-def calc_ave_ext(starpair_list, path, min_number=1, mask=[]):
+def calc_ave_ext(
+    starpair_list, path, outname="average_ext.fits", min_number=3, mask=[]
+):
+    """
+    Calculate the average extinction curve
+
+    Parameters
+    ----------
+    starpair_list : list of strings
+        List of star pairs for which to calculate the average extinction curve, in the format "reddenedstarname_comparisonstarname" (no spaces)
+
+    path : string
+        Path to the data files
+
+    outname : string [default="average_ext.fits"]
+        Name of the output fits file with the average extinction curve
+
+    min_number : int [default=3]
+        Minimum number of extinction curves that are required to measure the average extinction; if less than min_number of curves are available at certain wavelengths, the average extinction will still be calculated, but the number of points (npts) at those wavelengths will be set to zero (e.g. used in the plotting)
+
+     mask : list of tuples [default=[]]
+        List of tuples with wavelength regions (in micron) that need to be masked, e.g. [(2.55,2.61),(3.01,3.10)]
+
+    Returns
+    -------
+    Average extinction curve
+    """
     extdatas = []
     for starpair in starpair_list:
         extdata = ExtData("%s%s_ext.fits" % (path, starpair.lower()))
         extdatas.append(extdata)
     average = AverageExtData(extdatas, min_number=min_number, mask=mask)
-    average.save(path + "average_ext.fits")
+    average.save(path + outname)
 
 
 def main():


### PR DESCRIPTION
Small PR to make the naming of the average extinction curve a little more flexible.
This is to make the script compatible with scripts in the spex_nir_extinction repo.