### PR TITLE
Updating dust columns to always be tuples with uncertainties

### DIFF
--- a/measure_extinction/extdata.py
+++ b/measure_extinction/extdata.py
@@ -552,7 +552,9 @@ class ExtData:
             kindx = dwaves.argmin()
             if dwaves[kindx] < 0.1 * u.micron:
                 cav = self.exts["BAND"][kindx] / (calav - 1)
-                cavunc = np.absolute(cav * (self.uncs["BAND"][kindx] / calav))
+                cavunc = np.absolute(
+                    cav * (self.uncs["BAND"][kindx] / self.exts["BAND"][kindx])
+                )
                 avs.append(cav)
                 avs_unc.append(cavunc)
 

--- a/measure_extinction/extdata.py
+++ b/measure_extinction/extdata.py
@@ -690,7 +690,7 @@ class ExtData:
                 if np.sum(zvals) > 0:
                     self.uncs[curname][zvals] = fullav[1] / fullav[0]
 
-                # make sure measuremnts with npts = 0 have zero exts and uncs
+                # make sure measurements with npts = 0 have zero exts and uncs
                 zvals = self.npts[curname] <= 0
                 if np.sum(zvals) > 0:
                     self.exts[curname][zvals] = 0.0

--- a/measure_extinction/extdata.py
+++ b/measure_extinction/extdata.py
@@ -532,7 +532,7 @@ class ExtData:
         """
         Calculate A(V) from the observed extinction curve:
             - extrapolate from J, H, & K photometry
-            - assumes functional from Rieke, Rieke, & Paul (1989)
+            - assumes functional form from Rieke, Rieke, & Paul (1989)
 
         Parameters
         ----------

--- a/measure_extinction/extdata.py
+++ b/measure_extinction/extdata.py
@@ -530,11 +530,7 @@ class ExtData:
 
     def calc_RV(self):
         """
-        Calculate R(V) from the observed extinction curv            if len(np.atleast_1d(fullav)) == 1:
-                fullav = np.array([fullav, 0.0])
-            elif len(np.atleast_1d(fullav)) == 3:
-                fullav = np.array([fullav[0], 0.5 * (fullav[1] + fullav[2])])
-            for curname in self.exts.keys():e
+        Calculate R(V) from the observed extinction curve
 
         Parameters
         ----------

--- a/measure_extinction/extdata.py
+++ b/measure_extinction/extdata.py
@@ -861,11 +861,11 @@ class ExtData:
                             hcomment.append(f"{ckey} uncertainty")
                             hval.append(self.columns[f"{ckey}"][1])
                         elif len(self.columns[f"{ckey}"]) == 3:
-                            hname.append(f"{ckey}_MUNC")
-                            hcomment.append(f"{ckey} lower uncertainty")
-                            hval.append(self.columns[f"{ckey}"][1])
                             hname.append(f"{ckey}_PUNC")
                             hcomment.append(f"{ckey} upper uncertainty")
+                            hval.append(self.columns[f"{ckey}"][1])
+                            hname.append(f"{ckey}_MUNC")
+                            hcomment.append(f"{ckey} lower uncertainty")
                             hval.append(self.columns[f"{ckey}"][2])
                     else:
                         hval.append(self.columns[f"{ckey}"])

--- a/measure_extinction/extdata.py
+++ b/measure_extinction/extdata.py
@@ -685,6 +685,12 @@ class ExtData:
                 if np.sum(zvals) > 0:
                     self.uncs[curname][zvals] = fullav[1] / fullav[0]
 
+                # make sure measuremnts with npts = 0 have zero exts and uncs
+                zvals = self.npts[curname] <= 0
+                if np.sum(zvals) > 0:
+                    self.exts[curname][zvals] = 0.0
+                    self.uncs[curname][zvals] = 0.0
+
             self.type = "alax"
 
     def get_fitdata(

--- a/measure_extinction/extdata.py
+++ b/measure_extinction/extdata.py
@@ -532,7 +532,7 @@ class ExtData:
         """
         Calculate A(V) from the observed extinction curve:
             - extrapolate from J, H, & K photometry
-            - assumes functional from from Rieke, Rieke, & Paul (1989)
+            - assumes functional from Rieke, Rieke, & Paul (1989)
 
         Parameters
         ----------
@@ -563,6 +563,11 @@ class ExtData:
             av = np.average(avs, weights=weights)
             avunc = np.sqrt(1.0 / np.sum(weights))
             self.columns["AV"] = (av, avunc)
+        else:
+            warnings.warn(
+                "No JHK band measurement available in E(lambda-V) so no A(V) measurement",
+                stacklevel=2,
+            )
 
     def calc_RV(self):
         """

--- a/measure_extinction/plotting/plot_ext.py
+++ b/measure_extinction/plotting/plot_ext.py
@@ -202,7 +202,7 @@ def plot_extmodels(extdata, alax=False):
             # compute A(V)
             extdata.calc_AV()
             # convert the model curve from A(lambda)/A(V) to E(lambda-V), using the computed A(V) of the data.
-            y = (curve(x) - 1) * extdata.columns["AV"]
+            y = (curve(x) - 1) * extdata.columns["AV"][0]
         plt.plot(
             x.value,
             y,

--- a/measure_extinction/plotting/plot_ext.py
+++ b/measure_extinction/plotting/plot_ext.py
@@ -200,7 +200,7 @@ def plot_extmodels(extdata, alax=False):
             y = curve(x) / axav
         else:
             # compute A(V)
-            if "AV" not in extdata.columns["AV"]:
+            if "AV" not in extdata.columns.keys():
                 extdata.calc_AV()
             # convert the model curve from A(lambda)/A(V) to E(lambda-V), using the computed A(V) of the data.
             y = (curve(x) - 1) * extdata.columns["AV"][0]

--- a/measure_extinction/plotting/plot_ext.py
+++ b/measure_extinction/plotting/plot_ext.py
@@ -200,7 +200,8 @@ def plot_extmodels(extdata, alax=False):
             y = curve(x) / axav
         else:
             # compute A(V)
-            extdata.calc_AV()
+            if "AV" not in extdata.columns["AV"]:
+                extdata.calc_AV()
             # convert the model curve from A(lambda)/A(V) to E(lambda-V), using the computed A(V) of the data.
             y = (curve(x) - 1) * extdata.columns["AV"][0]
         plt.plot(

--- a/measure_extinction/tests/test_EbvAvRv.py
+++ b/measure_extinction/tests/test_EbvAvRv.py
@@ -2,6 +2,7 @@ import numpy as np
 import astropy.units as u
 from measure_extinction.extdata import ExtData
 
+
 def test_calc_ebv():
     text = ExtData()
     text.waves["BAND"] = np.array([0.438, 0.555]) * u.micron

--- a/measure_extinction/tests/test_EbvAvRv.py
+++ b/measure_extinction/tests/test_EbvAvRv.py
@@ -1,0 +1,65 @@
+import numpy as np
+import astropy.units as u
+from measure_extinction.extdata import ExtData
+
+def test_calc_ebv():
+    text = ExtData()
+    text.waves["BAND"] = np.array([0.438, 0.555]) * u.micron
+    text.exts["BAND"] = np.array([0.5, 0.0])
+    text.uncs["BAND"] = np.array([0.03, 0.0])
+
+    text.calc_EBV()
+    ebv = text.columns["EBV"]
+    assert isinstance(ebv, tuple)
+    assert ebv[0] == 0.5
+    assert ebv[1] == 0.03
+
+
+def test_calc_av():
+    text = ExtData()
+    text.waves["BAND"] = np.array([0.555, 2.19]) * u.micron
+    text.exts["BAND"] = np.array([0.0, -0.5])
+    text.uncs["BAND"] = np.array([0.0, 0.02])
+
+    text.calc_AV()
+    av = text.columns["AV"]
+    assert isinstance(av, tuple)
+    assert np.isclose(av[0], 0.56306, atol=1e-3)
+    assert np.isclose(av[1], 0.02252, atol=1e-3)
+
+
+def test_calc_rv_fromelv():
+    text = ExtData()
+    text.waves["BAND"] = np.array([0.438, 0.555, 2.19]) * u.micron
+    text.exts["BAND"] = np.array([0.5, 0.0, -1.5])
+    text.uncs["BAND"] = np.array([0.03, 0.0, 0.02])
+
+    text.calc_RV()
+    rv = text.columns["RV"]
+    assert isinstance(rv, tuple)
+    assert np.isclose(rv[0], 3.37837, atol=1e-3)
+    assert np.isclose(rv[1], 0.207647, atol=1e-3)
+
+
+def test_calc_rv_fromebvav():
+    text = ExtData()
+    text.columns["EBV"] = (0.5, 0.03)
+    text.columns["AV"] = (3.1 * 0.5, 0.04)
+
+    text.calc_RV()
+    rv = text.columns["RV"]
+    assert isinstance(rv, tuple)
+    assert np.isclose(rv[0], 3.1, atol=1e-3)
+    assert np.isclose(rv[1], 0.20247, atol=1e-3)
+
+
+def test_calc_rv_fromebvav_pmunc():
+    text = ExtData()
+    text.columns["EBV"] = (0.5, 0.02, 0.04)
+    text.columns["AV"] = (3.1 * 0.5, 0.05, 0.03)
+
+    text.calc_RV()
+    rv = text.columns["RV"]
+    assert isinstance(rv, tuple)
+    assert np.isclose(rv[0], 3.1, atol=1e-3)
+    assert np.isclose(rv[1], 0.20247, atol=1e-3)

--- a/measure_extinction/tests/test_extdata.py
+++ b/measure_extinction/tests/test_extdata.py
@@ -74,6 +74,7 @@ def test_calc_AV_RV():
 
     # calculate A(V)
     ext.calc_AV()
+    print(ext.columns["AV"])
     np.testing.assert_almost_equal(ext.columns["AV"], 2.5626900237367805)
 
     # calculate R(V)
@@ -144,3 +145,7 @@ def test_fit_spex_ext():  # only for alax=False (for now)
         (0.8680132704511972, 2.023865293614347, 2.5626900237367805),
     )
     np.testing.assert_almost_equal(extdata.columns["AV"], 2.5626900237367805)
+
+
+if __name__ == '__main__':
+    test_calc_AV_RV()

--- a/measure_extinction/tests/test_extdata.py
+++ b/measure_extinction/tests/test_extdata.py
@@ -74,12 +74,11 @@ def test_calc_AV_RV():
 
     # calculate A(V)
     ext.calc_AV()
-    print(ext.columns["AV"])
-    np.testing.assert_almost_equal(ext.columns["AV"], 2.5626900237367805)
+    np.testing.assert_almost_equal(ext.columns["AV"][0], 2.5626900237367805)
 
     # calculate R(V)
     ext.calc_RV()
-    np.testing.assert_almost_equal(ext.columns["RV"], 2.614989769244703)
+    np.testing.assert_almost_equal(ext.columns["RV"][0], 2.614989769244703)
 
 
 def test_hierarch_keyword():
@@ -120,7 +119,7 @@ def test_fit_band_ext():  # only for alax=False (for now)
         extdata.model["params"],
         (0.7593262393303228, 1.345528276482045, 2.6061368004634025),
     )
-    np.testing.assert_almost_equal(extdata.columns["AV"], 2.6061368004634025)
+    np.testing.assert_almost_equal(extdata.columns["AV"][0], 2.6061368004634025)
 
 
 def test_fit_spex_ext():  # only for alax=False (for now)
@@ -144,8 +143,4 @@ def test_fit_spex_ext():  # only for alax=False (for now)
         extdata.model["params"],
         (0.8680132704511972, 2.023865293614347, 2.5626900237367805),
     )
-    np.testing.assert_almost_equal(extdata.columns["AV"], 2.5626900237367805)
-
-
-if __name__ == '__main__':
-    test_calc_AV_RV()
+    np.testing.assert_almost_equal(extdata.columns["AV"][0], 2.5626900237367805)

--- a/setup.cfg
+++ b/setup.cfg
@@ -84,9 +84,11 @@ exclude_lines =
     def _ipython_key_completions_
 
 [flake8]
+max-line-length = 92
 exclude = sphinx,*parsetab.py,conftest.py,docs/conf.py,setup.py
 ignore = E203, E501, W503
 
 [pycodestyle]
+max-line-length = 92
 exclude = sphinx,*parsetab.py,conftest.py,docs/conf.py,setup.py
 ignore = E203, E501, W503


### PR DESCRIPTION
The three extdata member functions calc_EBV, calc_AV, and calc_RV now return tuples with (value, unc).  Previously, they only returned a float with the value.  The uncertainties are now calculated in these member functions.  This means that all use of these dust column measurements throughout the code now assume a tuple.  This was already the case when reading/writing extdata from/to disk.  The code should now be more consistent.

Changes were needed elsewhere to support all column measurements as tuples.

Also fixes a recently introduced bug.  Closes #97.