### PR TITLE
Add rebinning to a constant resolution for spectra and extinction data

### DIFF
--- a/docs/calc_extinction.rst
+++ b/docs/calc_extinction.rst
@@ -244,19 +244,17 @@ exists.
 .. plot::
 
    import pkg_resources
-
-   import numpy as np
+   import matplotlib.pyplot as plt
 
    from measure_extinction.stardata import StarData
    from measure_extinction.extdata import ExtData
 
    # get the location of the data files
-   data_path = pkg_resources.resource_filename('measure_extinction',
-                                               'data/')
+   data_path = pkg_resources.resource_filename("measure_extinction", "data/")
 
    # read in the observed data on the star
-   redstar = StarData('hd229238.dat', path=data_path)
-   compstar = StarData('hd204172.dat', path=data_path)
+   redstar = StarData("hd229238.dat", path=data_path)
+   compstar = StarData("hd204172.dat", path=data_path)
 
    # calculate the extinction curve
    extdata = ExtData()
@@ -272,12 +270,12 @@ exists.
    extdata.plot(ax)
 
    # finish configuring the plot
-   ax.set_title('HD229238/HD204172 extinction')
-   ax.set_xscale('log')
-   ax.set_xlabel('$\lambda$ [$\mu m$]')
-   ax.set_ylabel('$E(\lambda - V)/E(B-V)$')
-   ax.tick_params('both', length=10, width=2, which='major')
-   ax.tick_params('both', length=5, width=1, which='minor')
+   ax.set_title("HD229238/HD204172 extinction")
+   ax.set_xscale("log")
+   ax.set_xlabel(r"$\lambda$ [$\mu m$]")
+   ax.set_ylabel(r"$E(\lambda - V)/E(B-V)$")
+   ax.tick_params("both", length=10, width=2, which="major")
+   ax.tick_params("both", length=5, width=1, which="minor")
 
    # use the whitespace better
    fig.tight_layout()

--- a/docs/code_capabilities.rst
+++ b/docs/code_capabilities.rst
@@ -33,8 +33,27 @@ The photometry is stored in the dedicated BandData class to
 provide specific capabilities needed for handling photometric data.
 The spectroscopy is stored in SpecData class.
 
+The details of the data stored are:
+
+* file: name of DAT file
+* path: path of DAT file
+* data: dictionary of BandData and SpecData objects containing the stellar data
+* sptype: spectral type of star from DAT file
+* use_corfac: boolean for determining if corfacs should be used
+* corfac: dictonary of correction factors for spectral data
+* dereddened: boolean if the data has been dereddened
+* dereddenParams: dictionary of FM90 and CCM89 dereddening parameters
+* model_parameters: stellar atmosphere model parameters (for model based data)
+
 Member Functions
 ----------------
+
+The member functions of StarData include:
+
+* read: read in the data on a star based on a DAT formatted file
+* deredden: deredden the data based on FM90 (UV) and CCM89 (optical/NIR)
+* get_flat_data_arrays: get waves, fluxes, uncs as vectors combining all the data
+* plot: plot the stellar data given a matplotlib plot object
 
 BandData
 ========
@@ -45,8 +64,28 @@ Member Functions
 SpecData
 ========
 
+A spectrum is stored as part of `measure_extinction.extdata.SpecData`.
+The details of the data stored are:
+
+* waves: wavelengths with units
+* n_waves: number of wavelengths
+* wave_range: min/max of waves with units
+* fluxes: fluxes versus wavelengths with units
+* uncs: flux uncertainties versus wavelength with units
+* npts: number of measurements versus wavelength
+
 Member Functions
 ----------------
+
+The member functions of SpecData include:
+
+* read_spectra: generic read for a spectrum in a specifically formatted FITS file
+* read_fuse: read a FUSE spectrum
+* read_iue: read an IUE spectrum (includes cutting data > 3200 A)
+* read_stis: read a Hubble/STIS spectrum
+* read_spex: read a IRTF/SpeX spectrum (includes scaling by corfacs)
+* read_irs: read a Spitzer/IRS spectrum (includes scaling by corfacs, cutting above some waelength)
+* rebin_constres: rebin spectrum to a constant input resolution
 
 ExtData
 =======
@@ -69,9 +108,9 @@ Specfic times stored include (where src = data source),
 Member Functions
 ----------------
 
-There are a number of member functions for ExtData.
+The member functions of ExtData include:
 
-* calc_elx: calculate E(lambda-X) for all data sources present in both reddened and comparision StarData objects
+* calc_elx: calculate E(lambda-X) for all data sources present in both reddened and comparison StarData objects
 * calc_elx_bands: calculate E(lambda-X) for the "BAND" data
 * calc_elx_spectra: calculate E(lambda-X) for a single spectral data source
 * calc_EBV: determine E(B-V) based on E(lambda-V) "BAND" data
@@ -79,8 +118,13 @@ There are a number of member functions for ExtData.
 * calc_RV: determine R(V) using calc_EBV and calc_AV as needed
 * trans_elv_elvebv: calculate E(lambda-V)/E(B-V) based on E(lambda-V) and E(B-V)
 * trans_elv_alav: calculate A(lambda)/A(V) based on E(lambda-V) and A(V)
-* rebin_constres: rebin one data source extinction data to a constant resolution
+* rebin_constres: rebin one data source extinction data to a constant input resolution
 * get_fitdata: gets a tuple of vectors with (wavelengths, exts, uncs) that is useful for fitting
 * save: save the extinction curve to a FITS file
 * read: read an extinction curve from a FITS file
 * plot: plot the extinction curve given a matplotlib plot object
+
+.. note::
+   ExtData partially supports extinction curves relative to an arbitrary band.
+   Some member functions only support extinction curve relative to V band.
+   Work continues to update the code to allow arbitrary bands for all functions.

--- a/docs/code_capabilities.rst
+++ b/docs/code_capabilities.rst
@@ -4,7 +4,7 @@ Code Capabilities
 =================
 
 The code is built around two classes.
-StarData is for photometry and spectrosocpy of a single star.
+StarData is for photometry and spectroscopy of a single star.
 ExtData is for calculating and storing the extinction curve for a single
 sightline.
 
@@ -17,10 +17,10 @@ NASA's Infrared Telescope SpeX Instrument ("SpeX_SXD", "SpeX_LXD"),
 and Spitzer Infrared Spectrograph ("IRS")
 The strings in "" give the dictionary key.
 
-This package assumes the spectral data from a specific source is one the
+This package assumes the spectral data from a specific source is on the
 same wavelength grid for all stars/sightlines.
 This simplifies the extinction calculations.
-Code to do this is done for some data sources can be found in
+Code to do this for some data sources can be found in
 `measure_extinction.merge_obsspec`.
 
 StarData
@@ -33,14 +33,15 @@ The photometry is stored in the dedicated BandData class to
 provide specific capabilities needed for handling photometric data.
 The spectroscopy is stored in SpecData class.
 
-The details of the data stored are:
+The details of the data stored include:
 
 * file: name of DAT file
 * path: path of DAT file
 * data: dictionary of BandData and SpecData objects containing the stellar data
+* photonly: only photometry used (all spectroscopic data ignored)
 * sptype: spectral type of star from DAT file
 * use_corfac: boolean for determining if corfacs should be used
-* corfac: dictonary of correction factors for spectral data
+* corfac: dictionary of correction factors for spectral data
 * dereddened: boolean if the data has been dereddened
 * dereddenParams: dictionary of FM90 and CCM89 dereddening parameters
 * model_parameters: stellar atmosphere model parameters (for model based data)
@@ -64,7 +65,7 @@ Member Functions
 SpecData
 ========
 
-A spectrum is stored as part of `measure_extinction.extdata.SpecData`.
+A spectrum is stored as part of `measure_extinction.stardata.SpecData`.
 The details of the data stored are:
 
 * waves: wavelengths with units
@@ -84,7 +85,7 @@ The member functions of SpecData include:
 * read_iue: read an IUE spectrum (includes cutting data > 3200 A)
 * read_stis: read a Hubble/STIS spectrum
 * read_spex: read a IRTF/SpeX spectrum (includes scaling by corfacs)
-* read_irs: read a Spitzer/IRS spectrum (includes scaling by corfacs, cutting above some waelength)
+* read_irs: read a Spitzer/IRS spectrum (includes scaling by corfacs, cutting above some wavelength)
 * rebin_constres: rebin spectrum to a constant input resolution
 
 ExtData
@@ -92,7 +93,7 @@ ExtData
 
 The data that is stored as part of `measure_extinction.extdata.ExtData`
 is the extinction curve from each source and associated details.
-Specfic times stored include (where src = data source),
+Specific details stored include (where src = data source),
 
 * type: type of extinction measurement (e.g., elx, elxebv, alax)
 * type_rel_band: photometric band that is used for the relative extinction measurement (usually V band)

--- a/docs/code_capabilities.rst
+++ b/docs/code_capabilities.rst
@@ -1,0 +1,86 @@
+
+=================
+Code Capabilities
+=================
+
+The code is built around two classes.
+StarData is for photometry and spectrosocpy of a single star.
+ExtData is for calculating and storing the extinction curve for a single
+sightline.
+
+For both classes, the data is stored by the source of origin of the data.  Possible
+origins are band photometry ("BAND") or spectroscopy from the
+International Ultraviolet Explorer ("IUE"),
+Far-Ultraviolet Spectroscopic Explorer ("FUSE"),
+Hubble Space Telescope Imaging Spectrograph ("STIS"),
+NASA's Infrared Telescope SpeX Instrument ("SpeX_SXD", "SpeX_LXD"),
+and Spitzer Infrared Spectrograph ("IRS")
+The strings in "" give the dictionary key.
+
+This package assumes the spectral data from a specific source is one the
+same wavelength grid for all stars/sightlines.
+This simplifies the extinction calculations.
+Code to do this is done for some data sources can be found in
+`measure_extinction.merge_obsspec`.
+
+StarData
+========
+
+The data stored as part of `measure_extinction.stardata.StarData`
+is the photometry and spectroscopy for a
+single star, each dataset stored in a class itself.
+The photometry is stored in the dedicated BandData class to
+provide specific capabilities needed for handling photometric data.
+The spectroscopy is stored in SpecData class.
+
+Member Functions
+----------------
+
+BandData
+========
+
+Member Functions
+----------------
+
+SpecData
+========
+
+Member Functions
+----------------
+
+ExtData
+=======
+
+The data that is stored as part of `measure_extinction.extdata.ExtData`
+is the extinction curve from each source and associated details.
+Specfic times stored include (where src = data source),
+
+* type: type of extinction measurement (e.g., elx, elxebv, alax)
+* type_rel_band: photometric band that is used for the relative extinction measurement (usually V band)
+* waves[src]: wavelengths
+* exts[src]: extinction versus wavelength
+* uncs[src]: uncertainty in the extinction versus wavelength
+* npts[src]: number of measurements at each wavelength
+* names[src]: names of the photometric bands (only present for names["BAND"])
+* columns: dictionary of gas or dust column measurements (e.g., A(V), R(V), N(HI))
+* red_file: filename of the reddened star
+* comp_file: filename of the comparison star
+
+Member Functions
+----------------
+
+There are a number of member functions for ExtData.
+
+* calc_elx: calculate E(lambda-X) for all data sources present in both reddened and comparision StarData objects
+* calc_elx_bands: calculate E(lambda-X) for the "BAND" data
+* calc_elx_spectra: calculate E(lambda-X) for a single spectral data source
+* calc_EBV: determine E(B-V) based on E(lambda-V) "BAND" data
+* calc_AV: determine A(V) based on E(lambda-V) "BAND" data
+* calc_RV: determine R(V) using calc_EBV and calc_AV as needed
+* trans_elv_elvebv: calculate E(lambda-V)/E(B-V) based on E(lambda-V) and E(B-V)
+* trans_elv_alav: calculate A(lambda)/A(V) based on E(lambda-V) and A(V)
+* rebin_constres: rebin one data source extinction data to a constant resolution
+* get_fitdata: gets a tuple of vectors with (wavelengths, exts, uncs) that is useful for fitting
+* save: save the extinction curve to a FITS file
+* read: read an extinction curve from a FITS file
+* plot: plot the extinction curve given a matplotlib plot object

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,8 +29,9 @@ User Documentation
    :maxdepth: 2
 
    Extinction Calculation <calc_extinction.rst>
-   Observed Data Formats <data_formats.rst>
+   Capabilities <code_capabilities.rst>
    Plotting <plotting.rst>
+   Observed Data Formats <data_formats.rst>
    Stellar Models as Standards <model_standards.rst>
 
 Reporting Issues

--- a/measure_extinction/extdata.py
+++ b/measure_extinction/extdata.py
@@ -702,7 +702,7 @@ class ExtData:
 
     def rebin_constres(self, source, waverange, resolution):
         """
-        Rebin the source extinction curve it a fixed spectral resolution
+        Rebin the source extinction curve to a fixed spectral resolution
         and min/max wavelength range.
 
         Parameters
@@ -710,14 +710,14 @@ class ExtData:
         source : str
             source of extinction (i.e. "IUE", "IRS")
         waverange : [float, float]
-            Min/max of wavelength range
+            Min/max of wavelength range with units
         resolution : float
             Spectral resolution of rebinned extinction curve
 
         Returns
         -------
         measure_extinction ExtData
-            Object with source extinciton curve rebinned
+            Object with source extinction curve rebinned
 
         """
         if source == "BAND":
@@ -738,7 +738,8 @@ class ExtData:
             new_uncs = np.zeros((n_waves), dtype=float)
             new_npts = np.zeros((n_waves), dtype=int)
 
-            # check if uncetainties defined and set to
+            # check if uncertainties defined and set temporarily to 1
+            # needed to avoid infinite weights
             nouncs = False
             if np.sum(self.uncs[source] > 0.0) == 0:
                 nouncs = True
@@ -750,7 +751,7 @@ class ExtData:
                 (indxs,) = np.where(
                     (owaves >= full_wave_min[k])
                     & (owaves < full_wave_max[k])
-                    & (self.uncs[source] > 0.0)
+                    & (self.npts[source] > 0.0)
                 )
                 if len(indxs) > 0:
                     weights = 1.0 / np.square(self.uncs[source][indxs])

--- a/measure_extinction/extdata.py
+++ b/measure_extinction/extdata.py
@@ -705,7 +705,7 @@ class ExtData:
         ----------
         source : str
             source of extinction (i.e. "IUE", "IRS")
-        waverange : [float, float]
+        waverange : 2 element array of atropy Quantities
             Min/max of wavelength range with units
         resolution : float
             Spectral resolution of rebinned extinction curve
@@ -734,7 +734,7 @@ class ExtData:
             new_uncs = np.zeros((n_waves), dtype=float)
             new_npts = np.zeros((n_waves), dtype=int)
 
-            # check if uncertainties defined and set temporarily to 1
+            # check if uncertainties defined and set temporarily to 1 if not
             # needed to avoid infinite weights
             nouncs = False
             if np.sum(self.uncs[source] > 0.0) == 0:

--- a/measure_extinction/extdata.py
+++ b/measure_extinction/extdata.py
@@ -705,7 +705,7 @@ class ExtData:
         ----------
         source : str
             source of extinction (i.e. "IUE", "IRS")
-        waverange : 2 element array of atropy Quantities
+        waverange : 2 element array of astropy Quantities
             Min/max of wavelength range with units
         resolution : float
             Spectral resolution of rebinned extinction curve

--- a/measure_extinction/extdata.py
+++ b/measure_extinction/extdata.py
@@ -536,9 +536,6 @@ class ExtData:
             - extrapolate from J, H, & K photometry
             - assumes functional form from Rieke, Rieke, & Paul (1989)
 
-        Parameters
-        ----------
-
         Returns
         -------
         Updates self.columns["AV"]
@@ -574,9 +571,6 @@ class ExtData:
     def calc_RV(self):
         """
         Calculate R(V) from the observed extinction curve
-
-        Parameters
-        ----------
 
         Returns
         -------
@@ -628,8 +622,10 @@ class ExtData:
                 fullebv = _get_column_plus_unc(ebv)
 
             for curname in self.exts.keys():
-                self.uncs[curname] = (self.exts[curname] / fullebv[0]) * np.sqrt(
-                    np.square(self.uncs[curname] / self.exts[curname])
+                # only compute where there is data and exts is not zero
+                gvals = (self.exts[curname] != 0) & (self.npts[curname] > 0)
+                self.uncs[curname][gvals] = (self.exts[curname][gvals] / fullebv[0]) * np.sqrt(
+                    np.square(self.uncs[curname][gvals] / self.exts[curname][gvals])
                     + np.square(fullebv[1] / fullebv[0])
                 )
                 self.exts[curname] /= fullebv[0]
@@ -1444,9 +1440,6 @@ class ExtData:
     def fit_band_ext(self):
         """
         Fit the observed NIR extinction curve with a powerlaw model, based on the band data between 1 and 40 micron
-
-        Parameters
-        ----------
 
         Returns
         -------

--- a/measure_extinction/extdata.py
+++ b/measure_extinction/extdata.py
@@ -266,7 +266,7 @@ class ExtData:
     comp_file : string
         comparison star filename
 
-    columns : list of tuples of column measurements
+    columns : dict of tuples of column measurements
         measurements are A(V), R(V), N(HI), etc.
         tuples are measurement, uncertainty
 

--- a/measure_extinction/extdata.py
+++ b/measure_extinction/extdata.py
@@ -12,6 +12,7 @@ from scipy.optimize import curve_fit
 from scipy import stats
 
 from dust_extinction.conversions import AxAvToExv
+
 from measure_extinction.merge_obsspec import _wavegrid
 
 __all__ = ["ExtData", "AverageExtData"]

--- a/measure_extinction/plotting/plot_ext.py
+++ b/measure_extinction/plotting/plot_ext.py
@@ -707,7 +707,7 @@ def plot_extinction(
     fig, ax = plt.subplots(figsize=(10, 7))
 
     # read in extinction curve data for this star
-    if "_ext.fits" not in starpair:
+    if ".fits" not in starpair:
         fname = "%s%s_ext.fits" % (path, starpair.lower())
     else:
         fname = starpair

--- a/measure_extinction/plotting/plot_ext.py
+++ b/measure_extinction/plotting/plot_ext.py
@@ -130,7 +130,7 @@ def plot_average(
 
         # plot HI-lines if requested
         if HI_lines:
-            plot_HI(path, ax)
+            plot_HI(ax, wavenum=wavenum)
 
         # zoom in on a specific region if requested
         if range is not None:
@@ -294,7 +294,7 @@ def plot_fitmodel(extdata, alax=False, yoffset=0, res=False):
         )
 
 
-def plot_HI(path, ax):
+def plot_HI(ax, wavenum=False):
     """
     Indicate the HI-lines on the plot (between 912A and 10 micron)
 
@@ -302,12 +302,15 @@ def plot_HI(path, ax):
     ----------
     ax : AxesSubplot
         Axes of plot for which to add the HI-lines
+    wavenum : boolean [default=False]
+        Whether or not to plot the wavelengths as wavenumbers = 1/wavelength
 
     Returns
     -------
     Indicates HI-lines on the plot
     """
     # read in HI-lines
+    path = pkg_resources.resource_filename("measure_extinction", "data/")
     table = pd.read_table(path + "HI_lines.list", sep=r"\s+", comment="#")
     # group lines by series
     series_groups = table.groupby("n'")
@@ -327,10 +330,19 @@ def plot_HI(path, ax):
     for name, series in series_groups:
         # plot the lines
         for wave in series.wavelength:
-            ax.axvline(wave, color=colors(name - 1), lw=0.05, alpha=0.4)
+            if wavenum:
+                x = 1.0 / wave
+            else:
+                x = wave
+            ax.axvline(x, color=colors(name - 1), lw=0.05, alpha=0.4)
         # add the name of the series
+        mwave = series.wavelength.mean()
+        if wavenum:
+            xm = 1.0 / mwave
+        else:
+            xm = mwave
         ax.text(
-            series.wavelength.mean(),
+            xm,
             0.04,
             series_names[name],
             transform=ax.get_xaxis_transform(),
@@ -563,7 +575,7 @@ def plot_multi_extinction(
 
     # plot HI-lines if requested
     if HI_lines:
-        plot_HI(path, ax)
+        plot_HI(ax, wavenum=wavenum)
 
     # zoom in on a specific region if requested
     if range is not None:
@@ -688,7 +700,7 @@ def plot_extinction(
 
     # plot HI-lines if requested
     if HI_lines:
-        plot_HI(path, ax)
+        plot_HI(ax, wavenum=wavenum)
 
     # zoom in on a specific region if requested
     if range is not None:

--- a/measure_extinction/plotting/plot_ext.py
+++ b/measure_extinction/plotting/plot_ext.py
@@ -425,6 +425,7 @@ def plot_multi_extinction(
     multicolor=False,
     wavenum=False,
     figsize=None,
+    rebin_res=None,
     pdf=False,
 ):
     """
@@ -479,6 +480,9 @@ def plot_multi_extinction(
 
     figsize : tuple [default=None]
         Tuple with figure size (e.g. (8,15))
+
+    rebin_res : float
+        Spectral resolution to rebin extinction curves
 
     pdf : boolean [default=False]
         Whether or not to save the figure as a pdf file
@@ -675,7 +679,7 @@ def plot_extinction(
     wavenum : boolean [default=False]
         Whether or not to plot the wavelengths as wavenumbers = 1/wavelength
 
-    resolution : float
+    rebin_res : float
         Spectral resolution to rebin extinction curves
 
     pdf : boolean [default=False]
@@ -865,6 +869,7 @@ def main():
             exclude=args.exclude,
             wavenum=args.wavenum,
             log=args.log,
+            rebin_res=args.rebin_res,
             pdf=args.pdf,
         )
     else:  # plot all curves separately

--- a/measure_extinction/plotting/plot_ext.py
+++ b/measure_extinction/plotting/plot_ext.py
@@ -616,6 +616,7 @@ def plot_extinction(
     exclude=[],
     log=False,
     wavenum=False,
+    rebin_res=None,
     pdf=False,
 ):
     """
@@ -653,6 +654,9 @@ def plot_extinction(
     wavenum : boolean [default=False]
         Whether or not to plot the wavelengths as wavenumbers = 1/wavelength
 
+    resolution : float
+        Spectral resolution to rebin extinction curves
+
     pdf : boolean [default=False]
         Whether or not to save the figure as a pdf file
 
@@ -677,8 +681,18 @@ def plot_extinction(
     # create the plot
     fig, ax = plt.subplots(figsize=(10, 7))
 
-    # read in and plot the extinction curve data for this star
+    # read in extinction curve data for this star
     extdata = ExtData("%s%s_ext.fits" % (path, starpair.lower()))
+
+    # rebin if desired
+    if rebin_res is not None:
+        for src in extdata.exts.keys():
+            if src != "BAND":
+                rebin_waverange = np.array([min(extdata.waves[src]).to(u.micron).value,
+                       max(extdata.waves[src]).to(u.micron).value]) * u.micron
+                extdata.rebin_constres(src, rebin_waverange, rebin_res)
+
+    # plot extinction curve data
     extdata.plot(
         ax,
         alax=alax,
@@ -793,6 +807,12 @@ def main():
     parser.add_argument(
         "--wavenum", help="plot wavenumbers = 1/wavelengths", action="store_true"
     )
+    parser.add_argument(
+        "--rebin_res",
+        help="resolution in wavelength for rebinning spectral extinction",
+        type=float,
+        default=None,
+    )
     parser.add_argument("--pdf", help="save figure as a pdf file", action="store_true")
     args = parser.parse_args()
 
@@ -833,6 +853,7 @@ def main():
                 exclude=args.exclude,
                 wavenum=args.wavenum,
                 log=args.log,
+                rebin_res=args.rebin_res,
                 pdf=args.pdf,
             )
 

--- a/measure_extinction/plotting/plot_ext.py
+++ b/measure_extinction/plotting/plot_ext.py
@@ -679,8 +679,8 @@ def plot_extinction(
     wavenum : boolean [default=False]
         Whether or not to plot the wavelengths as wavenumbers = 1/wavelength
 
-    rebin_res : float
-        Spectral resolution to rebin extinction curves
+    rebin_res : float [default=None]
+        Spectral resolution to rebin extinction curve
 
     pdf : boolean [default=False]
         Whether or not to save the figure as a pdf file

--- a/measure_extinction/plotting/plot_ext.py
+++ b/measure_extinction/plotting/plot_ext.py
@@ -128,11 +128,11 @@ def plot_average(
 
         # plot Milky Way extinction models if requested
         if extmodels:
-            plot_extmodels(average, alax=True)
+            plot_extmodels(average, alax=True, wavenum=wavenum)
 
         # overplot a fitted model if requested
         if fitmodel:
-            plot_fitmodel(average, res=res)
+            plot_fitmodel(average, res=res, wavenum=wavenum)
 
         # plot HI-lines if requested
         if HI_lines:
@@ -172,7 +172,7 @@ def plot_average(
 
         # overplot a fitted model if requested
         if fitmodel:
-            plot_fitmodel(average, yoffset=yoffset)
+            plot_fitmodel(average, yoffset=yoffset, wavenum=wavenum)
 
 
 def plot_extmodels(extdata, alax=False, wavenum=False):
@@ -195,8 +195,6 @@ def plot_extmodels(extdata, alax=False, wavenum=False):
     Overplots extinction curve models
     """
     x = np.arange(0.1, 3.33, 0.01) * u.micron
-    if wavenum:
-        x = 1 / x
     Rvs = [2.0, 3.1, 4.0, 5.0]
     style = ["--", "-", ":", "-."]
     for i, cRv in enumerate(Rvs):
@@ -216,8 +214,12 @@ def plot_extmodels(extdata, alax=False, wavenum=False):
             # convert the model curve from A(lambda)/A(V) to E(lambda-V), using the computed A(V) of the data.
             y = (curve(x) - 1) * extdata.columns["AV"][0]
 
+        if wavenum:
+            px = 1 / x
+        else:
+            px = x
         plt.plot(
-            x.value,
+            px.value,
             y,
             style[i],
             color="k",
@@ -225,7 +227,8 @@ def plot_extmodels(extdata, alax=False, wavenum=False):
             linewidth=1,
             label="R(V) = {:4.1f}".format(cRv),
         )
-        plt.legend(bbox_to_anchor=(0.99, 0.9))
+        # allow to find the best position (supports regular and wavenum)
+        plt.legend()
 
 
 def plot_fitmodel(extdata, alax=False, yoffset=0, res=False, wavenum=False):
@@ -563,12 +566,12 @@ def plot_multi_extinction(
 
         # overplot a fitted model if requested
         if fitmodel:
-            plot_fitmodel(extdata, alax=alax, yoffset=yoffset)
+            plot_fitmodel(extdata, alax=alax, yoffset=yoffset, wavenum=wavenum)
 
     # overplot Milky Way extinction curve models if requested
     if extmodels:
         if alax:
-            plot_extmodels(extdata, alax)
+            plot_extmodels(extdata, alax, wavenum=wavenum)
         else:
             warnings.warn(
                 "Overplotting Milky Way extinction curve models on a figure with multiple observed extinction curves in E(lambda-V) units is disabled, because the model curves in these units are different for every star, and would overload the plot. Please, do one of the following if you want to overplot Milky Way extinction curve models: 1) Use the flag --alax to plot ALL curves in A(lambda)/A(V) units, OR 2) Plot all curves separately by removing the flag --onefig.",
@@ -735,11 +738,11 @@ def plot_extinction(
 
     # plot Milky Way extinction models if requested
     if extmodels:
-        plot_extmodels(extdata, alax)
+        plot_extmodels(extdata, alax, wavenum=wavenum)
 
     # overplot a fitted model if requested
     if fitmodel:
-        plot_fitmodel(extdata, alax=alax, res=True)
+        plot_fitmodel(extdata, alax=alax, res=True, wavenum=wavenum)
 
     # plot HI-lines if requested
     if HI_lines:

--- a/measure_extinction/plotting/plot_ext.py
+++ b/measure_extinction/plotting/plot_ext.py
@@ -700,7 +700,11 @@ def plot_extinction(
     fig, ax = plt.subplots(figsize=(10, 7))
 
     # read in extinction curve data for this star
-    extdata = ExtData("%s%s_ext.fits" % (path, starpair.lower()))
+    if "_ext.fits" not in starpair:
+        fname = "%s%s_ext.fits" % (path, starpair.lower())
+    else:
+        fname = starpair
+    extdata = ExtData(fname)
 
     # rebin if desired
     if rebin_res is not None:
@@ -747,12 +751,15 @@ def plot_extinction(
         outname = outname.replace(".pdf", "_zoom.pdf")
 
     # finish configuring the plot
-    ax.set_title(starpair.split("_")[0], fontsize=50)
-    if len(starpair.split("_")) > 1:
+    if extdata.red_file == "":
+        ax.set_title(starpair, fontsize=50)
+    else:
+        ax.set_title(extdata.red_file.replace(".dat", ""), fontsize=50)
+    if extdata.comp_file != "":
         ax.text(
             0.99,
             0.95,
-            "comparison: " + starpair.split("_")[1],
+            "comparison: " + extdata.comp_file.replace(".dat", ""),
             fontsize=25,
             horizontalalignment="right",
             transform=ax.transAxes,

--- a/measure_extinction/plotting/plot_ext.py
+++ b/measure_extinction/plotting/plot_ext.py
@@ -697,14 +697,15 @@ def plot_extinction(
 
     # finish configuring the plot
     ax.set_title(starpair.split("_")[0], fontsize=50)
-    ax.text(
-        0.99,
-        0.95,
-        "comparison: " + starpair.split("_")[1],
-        fontsize=25,
-        horizontalalignment="right",
-        transform=ax.transAxes,
-    )
+    if len(starpair.split("_")) > 1:
+        ax.text(
+            0.99,
+            0.95,
+            "comparison: " + starpair.split("_")[1],
+            fontsize=25,
+            horizontalalignment="right",
+            transform=ax.transAxes,
+        )
     if log:
         ax.set_xscale("log")
     if wavenum:

--- a/measure_extinction/plotting/plot_spec.py
+++ b/measure_extinction/plotting/plot_spec.py
@@ -110,6 +110,7 @@ def plot_multi_spectra(
     wavenum=False,
     deredden=False,
     pdf=False,
+    rebin_res=None,
     outname="all_spec.pdf",
 ):
     """
@@ -167,6 +168,9 @@ def plot_multi_spectra(
        Deredden the data based on dereddening parameters given in the DAT file.
        Generally used to deredden standards.
 
+    rebin_res : float
+        Spectral resolution for rebinning spectra
+
     outname : string [default="all_spec.pdf"]
         Name for the output pdf file
 
@@ -201,7 +205,7 @@ def plot_multi_spectra(
     for i, star in enumerate(starlist):
         # read in all bands and spectra for this star
         starobs = StarData(
-            "%s.dat" % star.lower(), path=path, use_corfac=True, deredden=deredden
+            "%s.dat" % star, path=path, use_corfac=True, deredden=deredden
         )
 
         # spread out the spectra if requested
@@ -323,6 +327,7 @@ def plot_spectrum(
     log=False,
     wavenum=False,
     deredden=False,
+    rebin_res=None,
     pdf=False,
 ):
     """
@@ -361,6 +366,9 @@ def plot_spectrum(
        Deredden the data based on dereddening parameters given in the DAT file.
        Generally used to deredden standards.
 
+    rebin_res : float
+        Spectral resolution for rebinning spectra
+
     pdf : boolean [default=False]
         Whether or not to save the figure as a pdf file
 
@@ -383,20 +391,29 @@ def plot_spectrum(
     fig, ax = plt.subplots(figsize=(13, 10))
 
     # read in and plot all bands and spectra for this star
-    starobs = StarData(
-        "%s.dat" % star.lower(), path=path, use_corfac=True, deredden=deredden
-    )
+    starobs = StarData("%s.dat" % star, path=path, use_corfac=True, deredden=deredden)
     if norm_range is not None:
         norm_range = norm_range * u.micron
+    # rebin spectra if desired
+    if rebin_res is not None:
+        gkeys = list(starobs.data.keys())
+        gkeys.remove("BAND")
+        for src in gkeys:
+            starobs.data[src].rebin_constres(starobs.data[src].wave_range, rebin_res)
+
     starobs.plot(
-        ax, norm_wave_range=norm_range, mlam4=mlam4, exclude=exclude, wavenum=wavenum
+        ax,
+        norm_wave_range=norm_range,
+        mlam4=mlam4,
+        exclude=exclude,
+        wavenum=wavenum,
     )
     # plot HI-lines if requested
     if HI_lines:
         plot_HI(path, ax)
 
     # define the output name
-    outname = star.lower() + "_spec.pdf"
+    outname = star + "_spec.pdf"
 
     # zoom in on a specific region if requested
     if range is not None:
@@ -495,6 +512,12 @@ def main():
         help="deredden the data based on saved parameters",
         action="store_true",
     )
+    parser.add_argument(
+        "--rebin_res",
+        help="resolution in wavelength for rebinning spectral extinction",
+        type=float,
+        default=None,
+    )
     parser.add_argument("--pdf", help="save figure as a pdf file", action="store_true")
     args = parser.parse_args()
 
@@ -511,6 +534,7 @@ def main():
             log=args.log,
             wavenum=args.wavenum,
             deredden=args.deredden,
+            rebin_res=args.rebin_res,
             pdf=args.pdf,
         )
     else:  # plot all spectra separately
@@ -530,6 +554,7 @@ def main():
                 log=args.log,
                 wavenum=args.wavenum,
                 deredden=args.deredden,
+                rebin_res=args.rebin_res,
                 pdf=args.pdf,
             )
 

--- a/measure_extinction/plotting/plot_spec.py
+++ b/measure_extinction/plotting/plot_spec.py
@@ -168,7 +168,7 @@ def plot_multi_spectra(
        Deredden the data based on dereddening parameters given in the DAT file.
        Generally used to deredden standards.
 
-    rebin_res : float
+    rebin_res : float [default=None]
         Spectral resolution for rebinning spectra
 
     outname : string [default="all_spec.pdf"]
@@ -207,6 +207,13 @@ def plot_multi_spectra(
         starobs = StarData(
             "%s.dat" % star, path=path, use_corfac=True, deredden=deredden
         )
+
+        # rebin spectra if desired
+        if rebin_res is not None:
+            gkeys = list(starobs.data.keys())
+            gkeys.remove("BAND")
+            for src in gkeys:
+                starobs.data[src].rebin_constres(starobs.data[src].wave_range, rebin_res)
 
         # spread out the spectra if requested
         # add extra whitespace when the luminosity class changes from main sequence to giant
@@ -366,7 +373,7 @@ def plot_spectrum(
        Deredden the data based on dereddening parameters given in the DAT file.
        Generally used to deredden standards.
 
-    rebin_res : float
+    rebin_res : float [default=None]
         Spectral resolution for rebinning spectra
 
     pdf : boolean [default=False]
@@ -514,7 +521,7 @@ def main():
     )
     parser.add_argument(
         "--rebin_res",
-        help="resolution in wavelength for rebinning spectral extinction",
+        help="resolution in wavelength for rebinning spectra",
         type=float,
         default=None,
     )

--- a/measure_extinction/plotting/plot_spec.py
+++ b/measure_extinction/plotting/plot_spec.py
@@ -398,7 +398,11 @@ def plot_spectrum(
     fig, ax = plt.subplots(figsize=(13, 10))
 
     # read in and plot all bands and spectra for this star
-    starobs = StarData("%s.dat" % star, path=path, use_corfac=True, deredden=deredden)
+    if ".dat" not in star:
+        fname = f"{star}.dat"
+    else:
+        fname = star
+    starobs = StarData(fname, path=path, use_corfac=True, deredden=deredden)
     if norm_range is not None:
         norm_range = norm_range * u.micron
     # rebin spectra if desired

--- a/measure_extinction/stardata.py
+++ b/measure_extinction/stardata.py
@@ -808,6 +808,60 @@ class SpecData:
         self.uncs = self.uncs.value * (u.Jy)
 
 
+    def rebin_constres(self, source, waverange, resolution):
+        """
+        Rebin the spectrum it a fixed spectral resolution
+        and min/max wavelength range.
+
+        Parameters
+        ----------
+        source : str
+            source of extinction (i.e. "IUE", "IRS")
+        waverange : [float, float]
+            Min/max of wavelength range
+        resolution : float
+            Spectral resolution of rebinned extinction curve
+
+        Returns
+        -------
+        measure_extinction SpecData
+            Object with rebinned spectrum
+
+        """
+        # setup new wavelength grid
+        full_wave, full_wave_min, full_wave_max = _wavegrid(
+            resolution, waverange.to(u.micron).value
+        )
+        n_waves = len(full_wave)
+
+        # setup the new rebinned vectors
+        new_waves = full_wave * u.micron
+        new_fluxes = np.zeros((n_waves), dtype=float)
+        new_uncs = np.zeros((n_waves), dtype=float)
+        new_npts = np.zeros((n_waves), dtype=int)
+
+        # rebin using a weighted average
+        owaves = self.waves.to(u.micron).value
+        for k in range(n_waves):
+            (indxs,) = np.where(
+                (owaves >= full_wave_min[k])
+                & (owaves < full_wave_max[k])
+                & (self.uncs > 0.0)
+            )
+            if len(indxs) > 0:
+                weights = 1.0 / np.square(self.uncs[indxs])
+                sweights = np.sum(weights)
+                new_fluxes[k] = np.sum(weights * self.fluxes[indxs]) / sweights
+                new_uncs[k] = 1.0 / np.sqrt(sweights)
+                new_npts[k] = np.sum(self.npts[indxs])
+
+        # update source values
+        self.waves = new_waves
+        self.fluxes = new_fluxes
+        self.uncs = new_uncs
+        self.npts = new_npts
+
+
 class StarData:
     """
     Photometric and spectroscopic data for a star

--- a/measure_extinction/stardata.py
+++ b/measure_extinction/stardata.py
@@ -842,10 +842,14 @@ class SpecData:
         # rebin using a weighted average
         owaves = self.waves.to(u.micron).value
         for k in range(n_waves):
+            # check for zero uncs includes to avoid divide by zero
+            # errors when the flux uncertainty of a real measurement
+            # is zero for any reason
             (indxs,) = np.where(
                 (owaves >= full_wave_min[k])
                 & (owaves < full_wave_max[k])
                 & (self.npts > 0.0)
+                & (self.uncs > 0.0)
             )
             if len(indxs) > 0:
                 weights = 1.0 / np.square(self.uncs[indxs].value)

--- a/measure_extinction/stardata.py
+++ b/measure_extinction/stardata.py
@@ -13,6 +13,8 @@ import astropy.units as u
 from dust_extinction.parameter_averages import CCM89
 from dust_extinction.shapes import _curve_F99_method
 
+from measure_extinction.merge_obsspec import _wavegrid
+
 __all__ = ["StarData", "BandData", "SpecData"]
 
 # Jy to ergs/(cm^2 s A)
@@ -806,7 +808,6 @@ class SpecData:
         # add units
         self.fluxes = self.fluxes.value * (u.Jy)
         self.uncs = self.uncs.value * (u.Jy)
-
 
     def rebin_constres(self, source, waverange, resolution):
         """

--- a/measure_extinction/stardata.py
+++ b/measure_extinction/stardata.py
@@ -811,15 +811,15 @@ class SpecData:
 
     def rebin_constres(self, waverange, resolution):
         """
-        Rebin the spectrum it a fixed spectral resolution
+        Rebin the spectrum to a fixed spectral resolution
         and min/max wavelength range.
 
         Parameters
         ----------
         waverange : [float, float]
-            Min/max of wavelength range
+            Min/max of wavelength range with units
         resolution : float
-            Spectral resolution of rebinned extinction curve
+            Spectral resolution of rebinned spectrum
 
         Returns
         -------
@@ -845,7 +845,7 @@ class SpecData:
             (indxs,) = np.where(
                 (owaves >= full_wave_min[k])
                 & (owaves < full_wave_max[k])
-                & (self.uncs > 0.0)
+                & (self.npts > 0.0)
             )
             if len(indxs) > 0:
                 weights = 1.0 / np.square(self.uncs[indxs].value)
@@ -882,6 +882,9 @@ class StarData:
 
     data : dict of key:BandData or SpecData
         key gives the type of data (e.g., BAND, IUE, IRS)
+
+    photonly: boolean
+        Only read in the photometry (no spectroscopy)
 
     corfac : dict of key:correction factors
         key gives the type (e.g., IRS, IRS_slope)

--- a/measure_extinction/stardata.py
+++ b/measure_extinction/stardata.py
@@ -816,7 +816,7 @@ class SpecData:
 
         Parameters
         ----------
-        waverange : [float, float]
+        waverange : 2 element array of atropy Quantities
             Min/max of wavelength range with units
         resolution : float
             Spectral resolution of rebinned spectrum
@@ -842,7 +842,7 @@ class SpecData:
         # rebin using a weighted average
         owaves = self.waves.to(u.micron).value
         for k in range(n_waves):
-            # check for zero uncs includes to avoid divide by zero
+            # check for zero uncs to avoid divide by zero
             # errors when the flux uncertainty of a real measurement
             # is zero for any reason
             (indxs,) = np.where(

--- a/measure_extinction/stardata.py
+++ b/measure_extinction/stardata.py
@@ -809,15 +809,13 @@ class SpecData:
         self.fluxes = self.fluxes.value * (u.Jy)
         self.uncs = self.uncs.value * (u.Jy)
 
-    def rebin_constres(self, source, waverange, resolution):
+    def rebin_constres(self, waverange, resolution):
         """
         Rebin the spectrum it a fixed spectral resolution
         and min/max wavelength range.
 
         Parameters
         ----------
-        source : str
-            source of extinction (i.e. "IUE", "IRS")
         waverange : [float, float]
             Min/max of wavelength range
         resolution : float
@@ -850,16 +848,16 @@ class SpecData:
                 & (self.uncs > 0.0)
             )
             if len(indxs) > 0:
-                weights = 1.0 / np.square(self.uncs[indxs])
+                weights = 1.0 / np.square(self.uncs[indxs].value)
                 sweights = np.sum(weights)
-                new_fluxes[k] = np.sum(weights * self.fluxes[indxs]) / sweights
+                new_fluxes[k] = np.sum(weights * self.fluxes[indxs].value) / sweights
                 new_uncs[k] = 1.0 / np.sqrt(sweights)
                 new_npts[k] = np.sum(self.npts[indxs])
 
-        # update source values
+        # update values
         self.waves = new_waves
-        self.fluxes = new_fluxes
-        self.uncs = new_uncs
+        self.fluxes = new_fluxes * self.fluxes.unit
+        self.uncs = new_uncs * self.uncs.unit
         self.npts = new_npts
 
 

--- a/measure_extinction/stardata.py
+++ b/measure_extinction/stardata.py
@@ -816,7 +816,7 @@ class SpecData:
 
         Parameters
         ----------
-        waverange : 2 element array of atropy Quantities
+        waverange : 2 element array of astropy Quantities
             Min/max of wavelength range with units
         resolution : float
             Spectral resolution of rebinned spectrum

--- a/measure_extinction/tests/test_plot_spec.py
+++ b/measure_extinction/tests/test_plot_spec.py
@@ -7,7 +7,7 @@ from measure_extinction.plotting.plot_spec import plot_multi_spectra, plot_spect
 def test_plot_spectra():
     # get the location of the data files
     data_path = pkg_resources.resource_filename("measure_extinction", "data/")
-    starlist = ["HD229238", "HD204172"]
+    starlist = ["hd229238", "hd204172"]
 
     # plot the spectra in separate figures
     for star in starlist:

--- a/measure_extinction/tests/test_rebin.py
+++ b/measure_extinction/tests/test_rebin.py
@@ -12,6 +12,8 @@ def test_spec_rebin_constres():
     # fake some simple data
     # flux values alternate between 1 and 2
     tres = 1000
+    # start at 1.001 to get an even number of points
+    # needed as the a and b arrays have to be equal
     twaves, tmp, tmp = _wavegrid(tres, [1.001, 10.0])
     spec.waves = twaves * u.micron
     n_test = len(twaves)
@@ -24,7 +26,7 @@ def test_spec_rebin_constres():
     spec.uncs = spec.fluxes * 0.05
     spec.npts = np.full((n_test), 1)
 
-    # rebin it using the ExtData member function
+    # rebin it using the SpecData member function
     gres = tres / 2.0
     rwaverange = [1.0, 10.0] * u.micron
     spec.rebin_constres(rwaverange, gres)
@@ -46,6 +48,8 @@ def test_ext_rebin_constres():
     # fake some simple data
     # ext values alternate between 1 and 2
     tres = 1000
+    # start at 1.001 to get an even number of points
+    # needed as the a and b arrays have to be equal
     twaves, tmp, tmp = _wavegrid(tres, [1.001, 10.0])
     ext.waves["TEST"] = twaves * u.micron
     n_test = len(twaves)
@@ -72,7 +76,3 @@ def test_ext_rebin_constres():
     # test all but the end elements as edge effects mean they will be different
     # weighted average with fractional weights gives 1.2 (equal weights would give 1.5)
     np.testing.assert_equal(ext.exts["TEST"][1:-1], np.full(len(nres) - 1, 1.2))
-
-
-if __name__ == "__main__":
-    test_spec_rebin_constres()

--- a/measure_extinction/tests/test_rebin.py
+++ b/measure_extinction/tests/test_rebin.py
@@ -1,0 +1,78 @@
+import numpy as np
+import astropy.units as u
+
+from measure_extinction.stardata import SpecData
+from measure_extinction.extdata import ExtData
+from measure_extinction.merge_obsspec import _wavegrid
+
+
+def test_spec_rebin_constres():
+    spec = SpecData("TEST")
+
+    # fake some simple data
+    # flux values alternate between 1 and 2
+    tres = 1000
+    twaves, tmp, tmp = _wavegrid(tres, [1.001, 10.0])
+    spec.waves = twaves * u.micron
+    n_test = len(twaves)
+    a = np.full((n_test // 2), 1.0)
+    b = np.full((n_test // 2), 2.0)
+    spec.fluxes = np.empty((a.size + b.size), dtype=a.dtype)
+    spec.fluxes[0::2] = a
+    spec.fluxes[1::2] = b
+    spec.fluxes *= u.erg / ((u.cm ** 2) * u.s * u.angstrom)
+    spec.uncs = spec.fluxes * 0.05
+    spec.npts = np.full((n_test), 1)
+
+    # rebin it using the ExtData member function
+    gres = tres / 2.0
+    rwaverange = [1.0, 10.0] * u.micron
+    spec.rebin_constres(rwaverange, gres)
+
+    ndelt = spec.waves[1:] - spec.waves[0:-1]
+    nwave = 0.5 * (spec.waves[1:] + spec.waves[0:-1])
+    nres = nwave / ndelt
+
+    # not quite the same, but very close
+    np.testing.assert_allclose(nres, np.full(len(nres), gres), rtol=0.001)
+
+    # test all but the end elements as edge effects mean they will be different
+    np.testing.assert_equal(spec.fluxes[1:-1].value, np.full(len(nres) - 1, 1.2))
+
+
+def test_ext_rebin_constres():
+    ext = ExtData()
+
+    # fake some simple data
+    # ext values alternate between 1 and 2
+    tres = 1000
+    twaves, tmp, tmp = _wavegrid(tres, [1.001, 10.0])
+    ext.waves["TEST"] = twaves * u.micron
+    n_test = len(twaves)
+    a = np.full((n_test // 2), 1.0)
+    b = np.full((n_test // 2), 2.0)
+    ext.exts["TEST"] = np.empty((a.size + b.size), dtype=a.dtype)
+    ext.exts["TEST"][0::2] = a
+    ext.exts["TEST"][1::2] = b
+    ext.uncs["TEST"] = ext.exts["TEST"] * 0.05
+    ext.npts["TEST"] = np.full((n_test), 1)
+
+    # rebin it using the ExtData member function
+    gres = tres / 2.0
+    rwaverange = [1.0, 10.0] * u.micron
+    ext.rebin_constres("TEST", rwaverange, gres)
+
+    ndelt = ext.waves["TEST"][1:] - ext.waves["TEST"][0:-1]
+    nwave = 0.5 * (ext.waves["TEST"][1:] + ext.waves["TEST"][0:-1])
+    nres = nwave / ndelt
+
+    # not quite the same, but very close
+    np.testing.assert_allclose(nres, np.full(len(nres), gres), rtol=0.001)
+
+    # test all but the end elements as edge effects mean they will be different
+    # weighted average with fractional weights gives 1.2 (equal weights would give 1.5)
+    np.testing.assert_equal(ext.exts["TEST"][1:-1], np.full(len(nres) - 1, 1.2))
+
+
+if __name__ == "__main__":
+    test_spec_rebin_constres()


### PR DESCRIPTION
Adds option to rebin to a specified constant spectral resolution for spectra and spectral extinction curves.  Documentation for the basic classes and capabilities including the rebinning included.

As part of the testing of the rebinning, some changes to the plotting scripts were made.  One change was to remove the forcing of all filenames to be lower case allowing for a wider range of filenames to be used.  Another was to switch from using the filenames to using the saved names of the reddened and comparison stars in the extinction FITS files.

Finally, the wavenum capability added previously in PR #81 did not fully work with the plotting scripts.  Updates were made to more fully support plotting versus 1/lambda.  The missing plotting capabilities were revealed during the rebin testing.

Fixes a few minor bugs found during this work.