### PR TITLE
Add option to fit sed with G23 only

### DIFF
--- a/measure_extinction/modeldata.py
+++ b/measure_extinction/modeldata.py
@@ -221,6 +221,9 @@ class ModelData(object):
         sed : dict
             fluxes for each spectral piece
 
+        fit_range : string, optional
+            keyword to toggle SED fitting to be done with G23 only or to also include curve_F99_method
+
         velocity : float, optional
             velocity of dust
 
@@ -234,13 +237,13 @@ class ModelData(object):
 
         # create the extinguished sed
         ext_sed = {}
-        if fit_range == "g23":
+        if fit_range.lower() == "g23":
             for cspec in self.fluxes.keys():
                 shifted_waves = (1.0 - velocity / 2.998e5) * self.waves[cspec]
                 axav = g23mod(shifted_waves)
                 ext_sed[cspec] = sed[cspec] * (10 ** (-0.4 * axav * params[0]))
 
-        elif fit_range == "all":
+        elif fit_range.lower() == "all":
             optnir_axav_x = np.flip(1.0 / (np.arange(0.35, 30.0, 0.1) * u.micron))
             optnir_axav_y = g23mod(optnir_axav_x)
 
@@ -255,11 +258,11 @@ class ModelData(object):
                     shifted_waves,
                     Rv,
                     C1,
-                    params[2], #C2
-                    params[3], #C3
-                    params[4], #C4
-                    xo=params[5], #xo
-                    gamma=params[6], #gamma
+                    params[2],  # C2
+                    params[3],  # C3
+                    params[4],  # C4
+                    xo=params[5],  # xo
+                    gamma=params[6],  # gamma
                     optnir_axav_x=optnir_axav_x.value,
                     optnir_axav_y=optnir_axav_y,
                     valid_x_range=[0.033, 11.0],
@@ -276,6 +279,11 @@ class ModelData(object):
             #     shifted_waves = (1.0 - velocity / 2.998e5) * self.waves[cspec]
             #     axav = g23mod(shifted_waves)
             #     ext_sed[cspec] = sed[cspec] * (10 ** (-0.4 * axav * params[0]))
+
+        else:
+            raise ValueError(
+                "Incorrect input for fit_range argument in dust_extinguished_sed(). Available options are: g23, all"
+            )
 
         return ext_sed
 

--- a/measure_extinction/utils/fit_model.py
+++ b/measure_extinction/utils/fit_model.py
@@ -64,7 +64,7 @@ class FitInfo(object):
         self.weights = weights
         self.velocities = np.array([stellar_velocity, 0.0])
 
-    def lnlike(self, params, obsdata, modeldata):
+    def lnlike(self, params, obsdata, modeldata, fit_range="all"):
         """
         Compute the natural log of the likelihood that the data
         fits the model.
@@ -73,6 +73,7 @@ class FitInfo(object):
         ----------
         params : floats
             parameters of the model
+            params = [logT, logg, logZ, Av, Rv, C2, C3, C4, x0, gamma, HI_gal, HI_mw]
 
         obsdata : StarData object
             observed data for a reddened star
@@ -85,7 +86,8 @@ class FitInfo(object):
 
         # dust_extinguished sed
         ext_modsed = modeldata.dust_extinguished_sed(
-            params[3:10], modsed, velocity=self.velocities[0]
+            params[3:10], modsed, fit_range=fit_range,
+            velocity=self.velocities[0]
         )
 
         # hi_abs sed
@@ -143,7 +145,7 @@ class FitInfo(object):
         return lnp
 
     @staticmethod
-    def lnprob(params, obsdata, modeldata, fitinfo):
+    def lnprob(params, obsdata, modeldata, fitinfo, fit_range="all"):
         """
         Compute the natural log of the probability
 
@@ -167,7 +169,7 @@ class FitInfo(object):
         if lnp == lnp_bignnum:
             return lnp
         else:
-            return lnp + fitinfo.lnlike(params, obsdata, modeldata)
+            return lnp + fitinfo.lnlike(params, obsdata, modeldata, fit_range=fit_range)
 
     def check_param_limits(self, params):
         """

--- a/measure_extinction/utils/fit_model.py
+++ b/measure_extinction/utils/fit_model.py
@@ -98,7 +98,10 @@ class FitInfo(object):
 
         lnl = 0.0
         for cspec in hi_ext_modsed.keys():
-            gvals = (self.weights[cspec] > 0) & (np.isfinite(hi_ext_modsed[cspec]))
+            try:
+                gvals = (self.weights[cspec] > 0) & (np.isfinite(hi_ext_modsed[cspec]))
+            except ValueError:
+                raise ValueError("Oops! The model data and reddened star data did not match.\n Hint: Make sure that the BAND name in the .dat files match.")
             chiarr = np.square(
                 (
                     obsdata.data[cspec].fluxes[gvals].value

--- a/measure_extinction/utils/fit_model.py
+++ b/measure_extinction/utils/fit_model.py
@@ -86,8 +86,7 @@ class FitInfo(object):
 
         # dust_extinguished sed
         ext_modsed = modeldata.dust_extinguished_sed(
-            params[3:10], modsed, fit_range=fit_range,
-            velocity=self.velocities[0]
+            params[3:10], modsed, fit_range=fit_range, velocity=self.velocities[0]
         )
 
         # hi_abs sed
@@ -101,7 +100,9 @@ class FitInfo(object):
             try:
                 gvals = (self.weights[cspec] > 0) & (np.isfinite(hi_ext_modsed[cspec]))
             except ValueError:
-                raise ValueError("Oops! The model data and reddened star data did not match.\n Hint: Make sure that the BAND name in the .dat files match.")
+                raise ValueError(
+                    "Oops! The model data and reddened star data did not match.\n Hint: Make sure that the BAND name in the .dat files match."
+                )
             chiarr = np.square(
                 (
                     obsdata.data[cspec].fluxes[gvals].value


### PR DESCRIPTION
The full pull request includes two commits. 

The first commit adds an argument to `dust_extinguished_sed()` function in `model_data.py:212`, to take in a keyword that allows the sed to only be fit with `G23()`. 

`dust_extinguished_sed()` is called by `lnlike()` in `fit_model.py:88`, which in turn is called by `lnprob()` in `fit_model.py:151`
both `lnlike()` and `lnprob()` are updated to take in the new keyword "g23" as an optional argument. These were made optional arguments as not to break anything that continues to use these functions without the new argument. The default keyword is set to "all", which executes the original sed fitting in `dust_extinguished_sed()`, rather than `G23` only. The original sed fitting, done using the `_curve_F99_method()` can be called by excluding the new argument, when calling `lnlike()`, `lnprob()`, and/or `dust_extinguished_sed()`. 

The second commit adds a warning if mismatched band information is provided, between the model and reddened star data.