### PR TITLE
Correctly compute reddened photometry

### DIFF
--- a/measure_extinction/modeldata.py
+++ b/measure_extinction/modeldata.py
@@ -85,8 +85,8 @@ class ModelData(object):
         self.band_names = band_names
 
         # add in special "model_full" spectra for use in computing the reddened band fluxes
-        self.n_spectra += 1
-        self.spectra_names = self.spectra_names + ["MODEL_FULL"]
+        self.spectra_names = spectra_names + ["MODEL_FULL"]
+        print(self.spectra_names)
 
         # photometric and spectroscopic data
         self.n_spectra = len(spectra_names) + 1
@@ -107,6 +107,7 @@ class ModelData(object):
 
         # read and store the model data
         for k, cfile in enumerate(modelfiles):
+            print(cfile)
             moddata = StarData(cfile, path=path)
 
             # model parameters
@@ -149,21 +150,20 @@ class ModelData(object):
         self.temps_min = min(self.temps)
         self.temps_max = max(self.temps)
         self.temps_width2 = (self.temps_max - self.temps_min) ** 2
-        if self.temps_width2 == 0:
-            self.temps_width2 == 1.0
+        if self.temps_width2 == 0.0:
+            self.temps_width2 = 1.0
 
         self.gravs_min = min(self.gravs)
         self.gravs_max = max(self.gravs)
         self.gravs_width2 = (self.gravs_max - self.gravs_min) ** 2
-        if self.gravs_width2 == 0:
-            self.gravs_width2 == 1.0
+        if self.gravs_width2 == 0.0:
+            self.gravs_width2 = 1.0
 
         self.mets_min = min(self.mets)
         self.mets_max = max(self.mets)
         self.mets_width2 = (self.mets_max - self.mets_min) ** 2
-        if self.mets_width2 == 0:
+        if self.mets_width2 == 0.0:
             self.mets_width2 = 1.0
-        # self.mets_width2 *= 4.0
 
     def stellar_sed(self, params, velocity=None):
         """
@@ -184,6 +184,7 @@ class ModelData(object):
         """
         # compute the distance between model params and grid points
         #    probably a better way using a kdtree
+        print(self.temps_width2)
         dist2 = (
             (params[0] - self.temps) ** 2 / self.temps_width2
             + (params[1] - self.gravs) ** 2 / self.gravs_width2

--- a/measure_extinction/modeldata.py
+++ b/measure_extinction/modeldata.py
@@ -92,7 +92,7 @@ class ModelData(object):
         # photometric and spectroscopic data +2 for "BANDS" and "MODEL_FULL"
         self.n_spectra = len(spectra_names) + 2
         # add in special "model_full" spectra for use in computing the reddened band fluxes
-        self.spectra_names = spectra_names + ["MODEL_FULL"]
+        self.spectra_names = spectra_names + ["MODEL_FULL_LOWRES"]
         self.waves = {}
         self.fluxes = {}
         self.flux_uncs = {}
@@ -311,9 +311,9 @@ class ModelData(object):
         # update the BAND fluxes by integrating the reddened MODEL_FULL spectrum
         band_sed = np.zeros(self.n_bands)
         for k, cband in enumerate(self.band_names):
-            gvals = np.isfinite(ext_sed["MODEL_FULL"])
-            iwave = (1.0 - velocity / 2.998e5) * self.waves["MODEL_FULL"][gvals]
-            iflux = ext_sed["MODEL_FULL"][gvals]
+            gvals = np.isfinite(ext_sed["MODEL_FULL_LOWRES"])
+            iwave = (1.0 - velocity / 2.998e5) * self.waves["MODEL_FULL_LOWRES"][gvals]
+            iflux = ext_sed["MODEL_FULL_LOWRES"][gvals]
             iresp = self.band_resp[cband](iwave)
             inttop = np.trapezoid(iwave * iresp * iflux, iwave)
             intbot = np.trapezoid(iwave * iresp, iwave)

--- a/measure_extinction/modeldata.py
+++ b/measure_extinction/modeldata.py
@@ -84,6 +84,10 @@ class ModelData(object):
         self.n_bands = len(band_names)
         self.band_names = band_names
 
+        # add in special "model_full" spectra for use in computing the reddened band fluxes
+        self.n_spectra += 1
+        self.spectra_names = self.spectra_names + ["MODEL_FULL"]
+
         # photometric and spectroscopic data
         self.n_spectra = len(spectra_names) + 1
         self.spectra_names = spectra_names
@@ -95,7 +99,7 @@ class ModelData(object):
             self.fluxes[cspec] = None
             self.flux_uncs[cspec] = None
 
-        # initialize the BAND dictonary entry as the number of elements
+        # initialize the BAND dictionary entry as the number of elements
         # is set by the desired bands, not the bands in the files
         self.waves["BAND"] = np.zeros((self.n_bands))
         self.fluxes["BAND"] = np.zeros((self.n_models, self.n_bands))

--- a/measure_extinction/modeldata.py
+++ b/measure_extinction/modeldata.py
@@ -140,8 +140,12 @@ class ModelData(object):
                         self.flux_uncs[cspec][k, i] = band_flux[1]
 
                         # read in the band response functions for determining the reddened photometry
-                        band_filename = f"John{cband}.dat"    # needs updating for HST (+other) bands
-                        bp = SpectralElement.from_file(f"{band_resp_path}/{band_filename}")
+                        band_filename = (
+                            f"John{cband}.dat"  # needs updating for HST (+other) bands
+                        )
+                        bp = SpectralElement.from_file(
+                            f"{band_resp_path}/{band_filename}"
+                        )
                         self.band_resp[cband] = bp
                 else:
                     # get the spectral data
@@ -301,7 +305,7 @@ class ModelData(object):
             iresp = self.band_resp[cband](iwave)
             inttop = np.trapezoid(iwave * iresp * iflux, iwave)
             intbot = np.trapezoid(iwave * iresp, iwave)
-            band_sed[k] = inttop / intbot            
+            band_sed[k] = inttop / intbot
         print(ext_sed["BAND"])
         print(band_sed)
         ext_sed["BAND"] = band_sed

--- a/measure_extinction/modeldata.py
+++ b/measure_extinction/modeldata.py
@@ -155,7 +155,7 @@ class ModelData(object):
                                 bp_cam = "UVIS1"
                             bp = STS.band(f"WFC3,{bp_cam},{bp_info[1]}")
                         else:
-                            band_filename = f"John{cband}.dat"  # needs updating for HST (+other) bands
+                            band_filename = f"John{cband}.dat"
                             bp = SpectralElement.from_file(
                                 f"{band_resp_path}/{band_filename}"
                             )

--- a/measure_extinction/modeldata.py
+++ b/measure_extinction/modeldata.py
@@ -1,6 +1,7 @@
 import numpy as np
 import astropy.units as u
 from synphot import SpectralElement
+import stsynphot as STS
 
 from dust_extinction.shapes import _curve_F99_method
 from dust_extinction.parameter_averages import G23
@@ -140,12 +141,24 @@ class ModelData(object):
                         self.flux_uncs[cspec][k, i] = band_flux[1]
 
                         # read in the band response functions for determining the reddened photometry
-                        band_filename = (
-                            f"John{cband}.dat"  # needs updating for HST (+other) bands
-                        )
-                        bp = SpectralElement.from_file(
-                            f"{band_resp_path}/{band_filename}"
-                        )
+                        if "ACS" in cband:
+                            bp_info = cband.split("_")
+                            bp = STS.band(f"ACS,WFC1,{bp_info[1]}")
+                        elif "WFPC2" in cband:
+                            bp_info = cband.split("_")
+                            bp = STS.band(f"WFPC2,4,{bp_info[1]}")
+                        elif "WFC3" in cband:
+                            bp_info = cband.split("_")
+                            if bp_info[1] in ["F110W", "F160W"]:
+                                bp_cam = "IR"
+                            else:
+                                bp_cam = "UVIS1"
+                            bp = STS.band(f"WFC3,{bp_cam},{bp_info[1]}")
+                        else:
+                            band_filename = f"John{cband}.dat"  # needs updating for HST (+other) bands
+                            bp = SpectralElement.from_file(
+                                f"{band_resp_path}/{band_filename}"
+                            )
                         self.band_resp[cband] = bp
                 else:
                     # get the spectral data

--- a/measure_extinction/modeldata.py
+++ b/measure_extinction/modeldata.py
@@ -309,16 +309,17 @@ class ModelData(object):
             )
 
         # update the BAND fluxes by integrating the reddened MODEL_FULL spectrum
-        band_sed = np.zeros(self.n_bands)
-        for k, cband in enumerate(self.band_names):
-            gvals = np.isfinite(ext_sed["MODEL_FULL_LOWRES"])
-            iwave = (1.0 - velocity / 2.998e5) * self.waves["MODEL_FULL_LOWRES"][gvals]
-            iflux = ext_sed["MODEL_FULL_LOWRES"][gvals]
-            iresp = self.band_resp[cband](iwave)
-            inttop = np.trapezoid(iwave * iresp * iflux, iwave)
-            intbot = np.trapezoid(iwave * iresp, iwave)
-            band_sed[k] = inttop / intbot
-        ext_sed["BAND"] = band_sed
+        if "BAND" in self.fluxes.keys():
+            band_sed = np.zeros(self.n_bands)
+            for k, cband in enumerate(self.band_names):
+                gvals = np.isfinite(ext_sed["MODEL_FULL_LOWRES"])
+                iwave = (1.0 - velocity / 2.998e5) * self.waves["MODEL_FULL_LOWRES"][gvals]
+                iflux = ext_sed["MODEL_FULL_LOWRES"][gvals]
+                iresp = self.band_resp[cband](iwave)
+                inttop = np.trapezoid(iwave * iresp * iflux, iwave)
+                intbot = np.trapezoid(iwave * iresp, iwave)
+                band_sed[k] = inttop / intbot
+            ext_sed["BAND"] = band_sed
 
         return ext_sed
 

--- a/measure_extinction/modeldata.py
+++ b/measure_extinction/modeldata.py
@@ -89,12 +89,10 @@ class ModelData(object):
         # path for non-HST band response curves
         band_resp_path = f"{get_datapath()}/Band_RespCurves/"
 
+        # photometric and spectroscopic data +2 for "BANDS" and "MODEL_FULL"
+        self.n_spectra = len(spectra_names) + 2
         # add in special "model_full" spectra for use in computing the reddened band fluxes
         self.spectra_names = spectra_names + ["MODEL_FULL"]
-
-        # photometric and spectroscopic data
-        self.n_spectra = len(spectra_names) + 1
-        self.spectra_names = spectra_names
         self.waves = {}
         self.fluxes = {}
         self.flux_uncs = {}
@@ -313,14 +311,13 @@ class ModelData(object):
         # update the BAND fluxes by integrating the reddened MODEL_FULL spectrum
         band_sed = np.zeros(self.n_bands)
         for k, cband in enumerate(self.band_names):
-            iwave = (1.0 - velocity / 2.998e5) * self.waves["MODEL_FULL"]
-            iflux = ext_sed["MODEL_FULL"]
+            gvals = np.isfinite(ext_sed["MODEL_FULL"])
+            iwave = (1.0 - velocity / 2.998e5) * self.waves["MODEL_FULL"][gvals]
+            iflux = ext_sed["MODEL_FULL"][gvals]
             iresp = self.band_resp[cband](iwave)
             inttop = np.trapezoid(iwave * iresp * iflux, iwave)
             intbot = np.trapezoid(iwave * iresp, iwave)
             band_sed[k] = inttop / intbot
-        print(ext_sed["BAND"])
-        print(band_sed)
         ext_sed["BAND"] = band_sed
 
         return ext_sed

--- a/measure_extinction/stardata.py
+++ b/measure_extinction/stardata.py
@@ -153,7 +153,7 @@ class BandData:
         band_info : dict of band_name: value
             value is tuple of ( zeromag_flux, wavelength [micron] )
             The zeromag_flux is the flux in erg/cm2/s/A for a star of (Vega) mag=0. 
-               It gives the conversion factor from Vega magnitudes to erg/cm2/s/A.
+            It gives the conversion factor from Vega magnitudes to erg/cm2/s/A.
         """
         _johnson_band_names = ["U", "B", "V", "R", "I", "J", "H", "K", "L", "M"]
         _johnson_band_waves = np.array(

--- a/measure_extinction/stardata.py
+++ b/measure_extinction/stardata.py
@@ -1208,7 +1208,9 @@ class StarData:
         # read the spectra
         if not self.photonly:
             for line in self.datfile_lines:
-                if "IUE" in line:
+                if line[0] == "#":
+                    pass
+                elif "IUE" in line:
                     fname = _getspecfilename(line, self.path)
                     if os.path.isfile(fname):
                         self.data["IUE"] = SpecData("IUE")

--- a/measure_extinction/stardata.py
+++ b/measure_extinction/stardata.py
@@ -152,7 +152,8 @@ class BandData:
         -------
         band_info : dict of band_name: value
             value is tuple of ( zeromag_flux, wavelength [micron] )
-            The zeromag_flux is the flux in erg/cm2/s/A for a star of (Vega) mag=0. It gives the conversion factor from Vega magnitudes to erg/cm2/s/A.
+            The zeromag_flux is the flux in erg/cm2/s/A for a star of (Vega) mag=0. 
+               It gives the conversion factor from Vega magnitudes to erg/cm2/s/A.
         """
         _johnson_band_names = ["U", "B", "V", "R", "I", "J", "H", "K", "L", "M"]
         _johnson_band_waves = np.array(

--- a/measure_extinction/stardata.py
+++ b/measure_extinction/stardata.py
@@ -152,7 +152,7 @@ class BandData:
         -------
         band_info : dict of band_name: value
             value is tuple of ( zeromag_flux, wavelength [micron] )
-            The zeromag_flux is the flux in erg/cm2/s/A for a star of (Vega) mag=0. 
+            The zeromag_flux is the flux in erg/cm2/s/A for a star of (Vega) mag=0.
             It gives the conversion factor from Vega magnitudes to erg/cm2/s/A.
         """
         _johnson_band_names = ["U", "B", "V", "R", "I", "J", "H", "K", "L", "M"]
@@ -216,7 +216,16 @@ class BandData:
         ]
         # from Calamida et al. 2022 (Amp C)
         _wfc3_band_waves = np.array(
-            [0.270330, 0.335465, 0.477217, 0.624196, 0.764830, 0.802932, 1.153446, 1.536918]
+            [
+                0.270330,
+                0.335465,
+                0.477217,
+                0.624196,
+                0.764830,
+                0.802932,
+                1.153446,
+                1.536918,
+            ]
         )
 
         _wfc3_photflam = np.array(
@@ -904,7 +913,6 @@ class SpecData:
             fluxunit, equivalencies=u.spectral_density(self.waves)
         )
         self.uncs = self.uncs.to(fluxunit, equivalencies=u.spectral_density(self.waves))
-
 
     def read_niriss_soss(self, line, path="./"):
         """

--- a/measure_extinction/stardata.py
+++ b/measure_extinction/stardata.py
@@ -1208,35 +1208,35 @@ class StarData:
         # read the spectra
         if not self.photonly:
             for line in self.datfile_lines:
-                if line.find("IUE") == 0:
+                if "IUE" in line:
                     fname = _getspecfilename(line, self.path)
                     if os.path.isfile(fname):
                         self.data["IUE"] = SpecData("IUE")
                         self.data["IUE"].read_iue(line, path=self.path)
                     else:
                         warnings.warn(f"{fname} does not exist", UserWarning)
-                elif line.find("FUSE") == 0:
+                elif "FUSE" in line:
                     fname = _getspecfilename(line, self.path)
                     if os.path.isfile(fname):
                         self.data["FUSE"] = SpecData("FUSE")
                         self.data["FUSE"].read_fuse(line, path=self.path)
                     else:
                         warnings.warn(f"{fname} does not exist", UserWarning)
-                elif line.find("STIS_Opt") == 0:
+                elif "STIS_Opt" in line:
                     fname = _getspecfilename(line, self.path)
                     if os.path.isfile(fname):
                         self.data["STIS_Opt"] = SpecData("STIS_Opt")
                         self.data["STIS_Opt"].read_stis(line, path=self.path)
                     else:
                         warnings.warn(f"{fname} does not exist", UserWarning)
-                elif line.find("STIS") == 0:
+                elif "STIS" in line:
                     fname = _getspecfilename(line, self.path)
                     if os.path.isfile(fname):
                         self.data["STIS"] = SpecData("STIS")
                         self.data["STIS"].read_stis(line, path=self.path)
                     else:
                         warnings.warn(f"{fname} does not exist", UserWarning)
-                elif line.find("SpeX_SXD") == 0:
+                elif "SpeX_SXD" in line:
                     fname = _getspecfilename(line, self.path)
                     if os.path.isfile(fname):
                         self.data["SpeX_SXD"] = SpecData("SpeX_SXD")
@@ -1248,7 +1248,7 @@ class StarData:
                         )
                     else:
                         warnings.warn(f"{fname} does not exist", UserWarning)
-                elif line.find("SpeX_LXD") == 0:
+                elif "SpeX_LXD" in line:
                     fname = _getspecfilename(line, self.path)
                     if os.path.isfile(fname):
                         self.data["SpeX_LXD"] = SpecData("SpeX_LXD")
@@ -1260,7 +1260,7 @@ class StarData:
                         )
                     else:
                         warnings.warn(f"{fname} does not exist", UserWarning)
-                elif line.find("IRS") == 0 and line.find("IRS15") < 0:
+                elif ("IRS" in line) and "IRS15" not in line:
                     fname = _getspecfilename(line, self.path)
                     if os.path.isfile(fname):
                         self.data["IRS"] = SpecData("IRS")
@@ -1272,7 +1272,7 @@ class StarData:
                         )
                     else:
                         warnings.warn(f"{fname} does not exist", UserWarning)
-                elif line.find("NIRISS_SOSS") == 0:
+                elif "NIRISS_SOSS" in line:
                     fname = _getspecfilename(line, self.path)
                     if os.path.isfile(fname):
                         self.data["NIRISS_SOSS"] = SpecData("NIRISS_SOSS")
@@ -1282,7 +1282,7 @@ class StarData:
                         )
                     else:
                         warnings.warn(f"{fname} does not exist", UserWarning)
-                elif line.find("NIRCam_SS") == 0:
+                elif "NIRCam_SS" in line:
                     fname = _getspecfilename(line, self.path)
                     if os.path.isfile(fname):
                         self.data["NIRCam_SS"] = SpecData("NIRCam_SS")
@@ -1292,7 +1292,7 @@ class StarData:
                         )
                     else:
                         warnings.warn(f"{fname} does not exist", UserWarning)
-                elif line.find("MIRI_LRS") == 0:
+                elif "MIRI_LRS" in line:
                     fname = _getspecfilename(line, self.path)
                     if os.path.isfile(fname):
                         self.data["MIRI_LRS"] = SpecData("MIRI_LRS")
@@ -1302,7 +1302,7 @@ class StarData:
                         )
                     else:
                         warnings.warn(f"{fname} does not exist", UserWarning)
-                elif line.find("MIRI_IFU") == 0:
+                elif "MIRI_IFU" in line:
                     fname = _getspecfilename(line, self.path)
                     if os.path.isfile(fname):
                         self.data["MIRI_IFU"] = SpecData("MIRI_IFU")
@@ -1312,11 +1312,21 @@ class StarData:
                         )
                     else:
                         warnings.warn(f"{fname} does not exist", UserWarning)
-                elif line.find("MODEL_FULL") == 0:
+                elif "MODEL_FULL_LOWRES" in line:
+                    fname = _getspecfilename(line, self.path)
+                    if os.path.isfile(fname):
+                        self.data["MODEL_FULL_LOWRES"] = SpecData("MODEL_FULL_LOWRES")
+                        self.data["MODEL_FULL_LOWRES"].read_model_full(
+                            line,
+                            path=self.path,
+                        )
+                    else:
+                        warnings.warn(f"{fname} does not exist", UserWarning)
+                elif "MODEL_FULL" in line:
                     fname = _getspecfilename(line, self.path)
                     if os.path.isfile(fname):
                         self.data["MODEL_FULL"] = SpecData("MODEL_FULL")
-                        self.data["MODEL_FULL"].read_miri_ifu(
+                        self.data["MODEL_FULL"].read_model_full(
                             line,
                             path=self.path,
                         )

--- a/measure_extinction/stardata.py
+++ b/measure_extinction/stardata.py
@@ -1313,8 +1313,6 @@ class StarData:
                         )
                     else:
                         warnings.warn(f"{fname} does not exist", UserWarning)
-                else:
-                    warnings.warn(f"{line} not recognized", UserWarning)
 
         # if desired and the necessary dereddening parameters are present
         if deredden:

--- a/measure_extinction/stardata.py
+++ b/measure_extinction/stardata.py
@@ -904,6 +904,31 @@ class SpecData:
         )
         self.uncs = self.uncs.to(fluxunit, equivalencies=u.spectral_density(self.waves))
 
+
+    def read_niriss_soss(self, line, path="./"):
+        """
+        Read in Webb/NIRISS single object slitless spectra
+
+        Parameters
+        ----------
+        line : string
+            formatted line from DAT file
+            example: 'NIRISS_SOSS = hd029647_niriss_soss.fits'
+
+        path : string, optional
+            location of the FITS files path
+
+        Returns
+        -------
+        Updates self.(file, wave_range, waves, flux, uncs, npts, n_waves)
+        """
+        self.read_spectra(line, path)
+
+        self.fluxes = self.fluxes.to(
+            fluxunit, equivalencies=u.spectral_density(self.waves)
+        )
+        self.uncs = self.uncs.to(fluxunit, equivalencies=u.spectral_density(self.waves))
+
     def read_miri_lrs(self, line, path="./"):
         """
         Read in Webb/MIRI LRS spectra
@@ -937,6 +962,30 @@ class SpecData:
         line : string
             formatted line from DAT file
             example: 'MIRI_IFU = hd029647_miri_ifu.fits'
+
+        path : string, optional
+            location of the FITS files path
+
+        Returns
+        -------
+        Updates self.(file, wave_range, waves, flux, uncs, npts, n_waves)
+        """
+        self.read_spectra(line, path)
+
+        self.fluxes = self.fluxes.to(
+            fluxunit, equivalencies=u.spectral_density(self.waves)
+        )
+        self.uncs = self.uncs.to(fluxunit, equivalencies=u.spectral_density(self.waves))
+
+    def read_model_full(self, line, path="./"):
+        """
+        Read in full model spectra (only available for model spectra)
+
+        Parameters
+        ----------
+        line : string
+            formatted line from DAT file
+            example: 'MODEL_FULL = tlusty_z200t55000g475v10_full.fits'
 
         path : string, optional
             location of the FITS files path
@@ -1214,11 +1263,31 @@ class StarData:
                         )
                     else:
                         warnings.warn(f"{fname} does not exist", UserWarning)
+                elif line.find("NIRISS_SOSS") == 0:
+                    fname = _getspecfilename(line, self.path)
+                    if os.path.isfile(fname):
+                        self.data["NIRISS_SOSS"] = SpecData("NIRISS_SOSS")
+                        self.data["NIRISS_SOSS"].read_niriss_soss(
+                            line,
+                            path=self.path,
+                        )
+                    else:
+                        warnings.warn(f"{fname} does not exist", UserWarning)
                 elif line.find("NIRCam_SS") == 0:
                     fname = _getspecfilename(line, self.path)
                     if os.path.isfile(fname):
                         self.data["NIRCam_SS"] = SpecData("NIRCam_SS")
                         self.data["NIRCam_SS"].read_miri_ifu(
+                            line,
+                            path=self.path,
+                        )
+                    else:
+                        warnings.warn(f"{fname} does not exist", UserWarning)
+                elif line.find("MIRI_LRS") == 0:
+                    fname = _getspecfilename(line, self.path)
+                    if os.path.isfile(fname):
+                        self.data["MIRI_LRS"] = SpecData("MIRI_LRS")
+                        self.data["MIRI_LRS"].read_miri_lrs(
                             line,
                             path=self.path,
                         )
@@ -1234,6 +1303,18 @@ class StarData:
                         )
                     else:
                         warnings.warn(f"{fname} does not exist", UserWarning)
+                elif line.find("MODEL_FULL") == 0:
+                    fname = _getspecfilename(line, self.path)
+                    if os.path.isfile(fname):
+                        self.data["MODEL_FULL"] = SpecData("MODEL_FULL")
+                        self.data["MODEL_FULL"].read_miri_ifu(
+                            line,
+                            path=self.path,
+                        )
+                    else:
+                        warnings.warn(f"{fname} does not exist", UserWarning)
+                else:
+                    warnings.warn(f"{line} not recognized", UserWarning)
 
         # if desired and the necessary dereddening parameters are present
         if deredden:

--- a/measure_extinction/tests/test_extdata.py
+++ b/measure_extinction/tests/test_extdata.py
@@ -73,11 +73,11 @@ def test_calc_AV_RV():
 
     # calculate A(V)
     ext.calc_AV()
-    np.testing.assert_almost_equal(ext.columns["AV"][0], 2.5626900237367805)
+    np.allclose(ext.columns["AV"][0], 2.5626900237367805)
 
     # calculate R(V)
     ext.calc_RV()
-    np.testing.assert_almost_equal(ext.columns["RV"][0], 2.614989769244703)
+    np.allclose(ext.columns["RV"][0], 2.614989769244703)
 
 
 def test_hierarch_keyword():
@@ -92,9 +92,9 @@ def test_hierarch_keyword():
 
 def test_get_column_val():
     # single float value
-    np.testing.assert_almost_equal(_get_column_val(3.0), 3.0)
+    np.allclose(_get_column_val(3.0), 3.0)
     # tuple
-    np.testing.assert_almost_equal(_get_column_val((3.0, 1.0, 2.0)), 3.0)
+    np.allclose(_get_column_val((3.0, 1.0, 2.0)), 3.0)
 
 
 def test_fit_band_ext():  # only for alax=False (for now)
@@ -111,14 +111,14 @@ def test_fit_band_ext():  # only for alax=False (for now)
     waves, exts, res = np.loadtxt(
         f"{data_path}/fit_band_ext_result_hd229238_hd204172.txt", unpack=True
     )
-    np.testing.assert_almost_equal(extdata.model["waves"], waves)
-    np.testing.assert_almost_equal(extdata.model["exts"], exts)
-    np.testing.assert_almost_equal(extdata.model["residuals"], res)
-    np.testing.assert_almost_equal(
+    np.allclose(extdata.model["waves"], waves)
+    np.allclose(extdata.model["exts"], exts)
+    np.allclose(extdata.model["residuals"], res)
+    np.allclose(
         extdata.model["params"],
         (0.7593262393303228, 1.345528276482045, 2.6061368004634025),
     )
-    np.testing.assert_almost_equal(extdata.columns["AV"][0], 2.6061368004634025)
+    np.allclose(extdata.columns["AV"][0], 2.6061368004634025)
 
 
 def test_fit_spex_ext():  # only for alax=False (for now)
@@ -135,11 +135,11 @@ def test_fit_spex_ext():  # only for alax=False (for now)
     waves, exts, res = np.loadtxt(
         f"{data_path}/fit_spex_ext_result_hd229238_hd204172.txt", unpack=True
     )
-    np.testing.assert_almost_equal(extdata.model["waves"], waves)
-    np.testing.assert_almost_equal(extdata.model["exts"], exts)
-    np.testing.assert_almost_equal(extdata.model["residuals"], res)
-    np.testing.assert_almost_equal(
+    np.allclose(extdata.model["waves"], waves)
+    np.allclose(extdata.model["exts"], exts)
+    np.allclose(extdata.model["residuals"], res)
+    np.allclose(
         extdata.model["params"],
         (0.8680132704511972, 2.023865293614347, 2.5626900237367805),
     )
-    np.testing.assert_almost_equal(extdata.columns["AV"][0], 2.5626900237367805)
+    np.allclose(extdata.columns["AV"][0], 2.5626900237367805)

--- a/measure_extinction/utils/fit_model.py
+++ b/measure_extinction/utils/fit_model.py
@@ -97,7 +97,7 @@ class FitInfo(object):
         norm_data = np.average(obsdata.data["BAND"].fluxes.value)
 
         lnl = 0.0
-        for cspec in hi_ext_modsed.keys():
+        for cspec in obsdata.data.keys():
             try:
                 gvals = (self.weights[cspec] > 0) & (np.isfinite(hi_ext_modsed[cspec]))
             except ValueError:

--- a/measure_extinction/utils/make_all_tlusty_obsdata.py
+++ b/measure_extinction/utils/make_all_tlusty_obsdata.py
@@ -75,7 +75,7 @@ def decode_params_wd(filename):
     model_params["Teff"] = float(filename[tpos + 1 : gpos])
     model_params["logg"] = float(filename[gpos + 1 : periodpos - 1]) * 0.01
     model_params["vturb"] = 0.0
-    model_params["Z"] = 1.0   # ratio to solar
+    model_params["Z"] = 1.0  # ratio to solar
 
     if model_params["Teff"] < 10000.0:
         model_params["Teff"] *= 100.0
@@ -98,6 +98,9 @@ if __name__ == "__main__":
         choices=["v2", "v5", "v10"],
         default="v2",
         help="Microturbulent velocity (only applies to tlusty grid)",
+    )
+    parser.add_argument(
+        "--only_dat", help="only create the DAT files", action="store_true"
     )
 
     args = parser.parse_args()
@@ -133,4 +136,5 @@ if __name__ == "__main__":
             output_filebase=basename,
             output_path="/home/kgordon/Python/extstar_data",
             model_params=model_params,
+            only_dat=args.only_dat,
         )

--- a/measure_extinction/utils/make_obsdata_from_model.py
+++ b/measure_extinction/utils/make_obsdata_from_model.py
@@ -310,6 +310,23 @@ def make_obsdata_from_model(
         otable.write("%s/Models/%s" % (output_path, full_file), overwrite=True)
     specinfo["MODEL_FULL"] = full_file
 
+    # rebin to R=100 for speed of reddened photometry calculation
+    #   use a wavelength range that spans FUSE to Spitzer IRS
+    rbres_lowres = 100.0
+    wave_rebin_lowres, flux_rebin_lowres, npts_rebin_lowres = rebin_spectrum(
+        mwave.value, mflux.value, rbres_lowres, [912.0, 310000.0]
+    )
+    full_file_lowres = "%s_full_lowres.fits" % (output_filebase)
+    if not only_dat:
+        # save the full spectrum to a binary FITS table
+        otable = QTable()
+        otable["WAVELENGTH"] = Column(wave_rebin_lowres, unit=u.angstrom)
+        otable["FLUX"] = Column(flux_rebin_lowres, unit=fluxunit)
+        otable["SIGMA"] = Column(flux_rebin_lowres * 0.01, unit=fluxunit)
+        otable["NPTS"] = Column(npts_rebin_lowres)
+        otable.write("%s/Models/%s" % (output_path, full_file_lowres), overwrite=True)
+    specinfo["MODEL_FULL_LOWRES"] = full_file_lowres
+
     iue_file = "%s_iue.fits" % (output_filebase)
     if not only_dat:
         # IUE mock observation

--- a/measure_extinction/utils/make_obsdata_from_model.py
+++ b/measure_extinction/utils/make_obsdata_from_model.py
@@ -143,7 +143,7 @@ def get_phot(mwave, mflux, band_names, band_resp_filenames):
         intbot = np.trapezoid(mwave * iresp, mwave)
         bflux = inttop / intbot
         bflux_unc = 0.0
-        bdata.band_fluxes[ncband] = (bflux, bflux_unc) 
+        bdata.band_fluxes[ncband] = (bflux, bflux_unc)
 
     # calculate the band magnitudes from the fluxes
     bdata.get_band_mags_from_fluxes()
@@ -307,9 +307,7 @@ def make_obsdata_from_model(
         otable["FLUX"] = Column(flux_rebin, unit=fluxunit)
         otable["SIGMA"] = Column(flux_rebin * 0.01, unit=fluxunit)
         otable["NPTS"] = Column(npts_rebin)
-        otable.write(
-            "%s/Models/%s" % (output_path, full_file), overwrite=True
-        )
+        otable.write("%s/Models/%s" % (output_path, full_file), overwrite=True)
     specinfo["MODEL_FULL"] = full_file
 
     iue_file = "%s_iue.fits" % (output_filebase)
@@ -529,22 +527,38 @@ def make_obsdata_from_model(
             )
 
             (indxs,) = np.where(rb_iue["NPTS"] > 0)
-            ax.plot(rb_iue["WAVELENGTH"][indxs].to(u.micron), rb_iue["FLUX"][indxs], "r-")
+            ax.plot(
+                rb_iue["WAVELENGTH"][indxs].to(u.micron), rb_iue["FLUX"][indxs], "r-"
+            )
 
             (indxs,) = np.where(rb_nrc["NPTS"] > 0)
-            ax.plot(rb_nrc["WAVELENGTH"][indxs].to(u.micron), rb_nrc["FLUX"][indxs], "c-")
+            ax.plot(
+                rb_nrc["WAVELENGTH"][indxs].to(u.micron), rb_nrc["FLUX"][indxs], "c-"
+            )
 
             (indxs,) = np.where(rb_lrs["NPTS"] > 0)
-            ax.plot(rb_lrs["WAVELENGTH"][indxs].to(u.micron), rb_lrs["FLUX"][indxs], "r:")
+            ax.plot(
+                rb_lrs["WAVELENGTH"][indxs].to(u.micron), rb_lrs["FLUX"][indxs], "r:"
+            )
 
             (indxs,) = np.where(rb_niriss["NPTS"] > 0)
-            ax.plot(rb_niriss["WAVELENGTH"][indxs].to(u.micron), rb_niriss["FLUX"][indxs], "r-")
+            ax.plot(
+                rb_niriss["WAVELENGTH"][indxs].to(u.micron),
+                rb_niriss["FLUX"][indxs],
+                "r-",
+            )
 
             (indxs,) = np.where(rb_miri_lrs["NPTS"] > 0)
-            ax.plot(rb_miri_lrs["WAVELENGTH"][indxs].to(u.micron), rb_miri_lrs["FLUX"][indxs], "r--")
+            ax.plot(
+                rb_miri_lrs["WAVELENGTH"][indxs].to(u.micron),
+                rb_miri_lrs["FLUX"][indxs],
+                "r--",
+            )
 
             (indxs,) = np.where(rb_mrs["NPTS"] > 0)
-            ax.plot(rb_mrs["WAVELENGTH"][indxs].to(u.micron), rb_mrs["FLUX"][indxs], "g-")
+            ax.plot(
+                rb_mrs["WAVELENGTH"][indxs].to(u.micron), rb_mrs["FLUX"][indxs], "g-"
+            )
 
         ax.set_xscale("log")
         ax.set_yscale("log")

--- a/measure_extinction/utils/make_obsdata_from_model.py
+++ b/measure_extinction/utils/make_obsdata_from_model.py
@@ -299,6 +299,23 @@ def make_obsdata_from_model(
     # dictionary to saye names of spectroscopic filenames
     specinfo = {}
 
+    # rebin to R=100 for speed of reddened photometry calculation
+    #   use a wavelength range that spans FUSE to Spitzer IRS
+    rbres_lowres = 100.0
+    wave_rebin_lowres, flux_rebin_lowres, npts_rebin_lowres = rebin_spectrum(
+        mwave.value, mflux.value, rbres_lowres, [912.0, 310000.0]
+    )
+    full_file_lowres = "%s_full_lowres.fits" % (output_filebase)
+    if not only_dat:
+        # save the full spectrum to a binary FITS table
+        otable_lowres = QTable()
+        otable_lowres["WAVELENGTH"] = Column(wave_rebin_lowres, unit=u.angstrom)
+        otable_lowres["FLUX"] = Column(flux_rebin_lowres, unit=fluxunit)
+        otable_lowres["SIGMA"] = Column(flux_rebin_lowres * 0.01, unit=fluxunit)
+        otable_lowres["NPTS"] = Column(npts_rebin_lowres)
+        otable_lowres.write("%s/Models/%s" % (output_path, full_file_lowres), overwrite=True)
+    specinfo["MODEL_FULL_LOWRES"] = full_file_lowres
+
     full_file = "%s_full.fits" % (output_filebase)
     if not only_dat:
         # save the full spectrum to a binary FITS table
@@ -309,23 +326,6 @@ def make_obsdata_from_model(
         otable["NPTS"] = Column(npts_rebin)
         otable.write("%s/Models/%s" % (output_path, full_file), overwrite=True)
     specinfo["MODEL_FULL"] = full_file
-
-    # rebin to R=100 for speed of reddened photometry calculation
-    #   use a wavelength range that spans FUSE to Spitzer IRS
-    rbres_lowres = 100.0
-    wave_rebin_lowres, flux_rebin_lowres, npts_rebin_lowres = rebin_spectrum(
-        mwave.value, mflux.value, rbres_lowres, [912.0, 310000.0]
-    )
-    full_file_lowres = "%s_full_lowres.fits" % (output_filebase)
-    if not only_dat:
-        # save the full spectrum to a binary FITS table
-        otable = QTable()
-        otable["WAVELENGTH"] = Column(wave_rebin_lowres, unit=u.angstrom)
-        otable["FLUX"] = Column(flux_rebin_lowres, unit=fluxunit)
-        otable["SIGMA"] = Column(flux_rebin_lowres * 0.01, unit=fluxunit)
-        otable["NPTS"] = Column(npts_rebin_lowres)
-        otable.write("%s/Models/%s" % (output_path, full_file_lowres), overwrite=True)
-    specinfo["MODEL_FULL_LOWRES"] = full_file_lowres
 
     iue_file = "%s_iue.fits" % (output_filebase)
     if not only_dat:

--- a/measure_extinction/utils/make_obsdata_from_model.py
+++ b/measure_extinction/utils/make_obsdata_from_model.py
@@ -139,9 +139,11 @@ def get_phot(mwave, mflux, band_names, band_resp_filenames):
             exit()
             # a.waveset *= 1e4
         iresp = bp(mwave)
-        bflux = np.sum(iresp * mflux) / np.sum(iresp)
+        inttop = np.trapezoid(mwave * iresp * mflux, mwave)
+        intbot = np.trapezoid(mwave * iresp, mwave)
+        bflux = inttop / intbot
         bflux_unc = 0.0
-        bdata.band_fluxes[ncband] = (bflux, bflux_unc)
+        bdata.band_fluxes[ncband] = (bflux, bflux_unc) 
 
     # calculate the band magnitudes from the fluxes
     bdata.get_band_mags_from_fluxes()
@@ -297,6 +299,7 @@ def make_obsdata_from_model(
     # dictionary to saye names of spectroscopic filenames
     specinfo = {}
 
+    full_file = "%s_full.fits" % (output_filebase)
     if not only_dat:
         # save the full spectrum to a binary FITS table
         otable = QTable()
@@ -305,8 +308,9 @@ def make_obsdata_from_model(
         otable["SIGMA"] = Column(flux_rebin * 0.01, unit=fluxunit)
         otable["NPTS"] = Column(npts_rebin)
         otable.write(
-            "%s/Models/%s_full.fits" % (output_path, output_filebase), overwrite=True
+            "%s/Models/%s" % (output_path, full_file), overwrite=True
         )
+    specinfo["MODEL_FULL"] = full_file
 
     iue_file = "%s_iue.fits" % (output_filebase)
     if not only_dat:


### PR DESCRIPTION
Computed from the MODEL_FULL_LOWRES (R=100) spectrum. 

MODEL_FULL_LOWRES spectra required.  Bandpasses read in and used in dust_extinguished_sed modeldata member function.  

Corrected small bug in photometry computation.
Corrected bugs in StarData reading of spectra.
Corrected bug in determining the default width for Teff and logg for fitting.
Updated one test to use np.allclose instead of np.testing.asset_almost_equal (was failing with 1e-7 difference on Macs).

Closes #135.