### PR TITLE
Set weight=0 for obsdata = nans or infs

### DIFF
--- a/measure_extinction/model.py
+++ b/measure_extinction/model.py
@@ -285,7 +285,7 @@ class MEModel(object):
         for cspec in list(obsdata.data.keys()):
             # base weights
             self.weights[cspec] = np.full(len(obsdata.data[cspec].fluxes), 0.0)
-            gvals = (obsdata.data[cspec].npts > 0) & ~np.isnan(obsdata.data[cspec].fluxes) & np.isfinite(obsdata.data[cspec].fluxes)
+            gvals = (obsdata.data[cspec].npts > 0) & np.isfinite(obsdata.data[cspec].fluxes)
             self.weights[cspec][gvals] = 1.0 / obsdata.data[cspec].uncs[gvals].value
 
             x = 1.0 / obsdata.data[cspec].waves

--- a/measure_extinction/model.py
+++ b/measure_extinction/model.py
@@ -285,7 +285,7 @@ class MEModel(object):
         for cspec in list(obsdata.data.keys()):
             # base weights
             self.weights[cspec] = np.full(len(obsdata.data[cspec].fluxes), 0.0)
-            gvals = (obsdata.data[cspec].npts > 0) & ~np.isnan(obsdata.data[cspec].fluxes) & ~np.isinf(obsdata.data[cspec].fluxes)
+            gvals = (obsdata.data[cspec].npts > 0) & ~np.isnan(obsdata.data[cspec].fluxes) & np.isfinite(obsdata.data[cspec].fluxes)
             self.weights[cspec][gvals] = 1.0 / obsdata.data[cspec].uncs[gvals].value
 
             x = 1.0 / obsdata.data[cspec].waves

--- a/measure_extinction/model.py
+++ b/measure_extinction/model.py
@@ -285,7 +285,7 @@ class MEModel(object):
         for cspec in list(obsdata.data.keys()):
             # base weights
             self.weights[cspec] = np.full(len(obsdata.data[cspec].fluxes), 0.0)
-            gvals = obsdata.data[cspec].npts > 0
+            gvals = (obsdata.data[cspec].npts > 0) & ~np.isnan(obsdata.data[cspec].fluxes) & ~np.isinf(obsdata.data[cspec].fluxes)
             self.weights[cspec][gvals] = 1.0 / obsdata.data[cspec].uncs[gvals].value
 
             x = 1.0 / obsdata.data[cspec].waves


### PR DESCRIPTION
Expand the check for `npts > 0` to also include a check for `nan`s or `inf`s in the observed data. Then set weights only for the observed data where there are no `nan`s or +/- `inf`s. The remainder of the weights will remain zero.