### PR TITLE
Use Rv bounds for G23 Rv range

### DIFF
--- a/measure_extinction/model.py
+++ b/measure_extinction/model.py
@@ -470,7 +470,10 @@ class MEModel(object):
         extinguished sed : dict
             SED with {'bands': band_sed, 'spec': spec_sed, ...}
         """
-        g23mod = G23(Rv=self.Rv.value)
+        g23mod = G23()
+
+        g23mod.Rv_range = self.Rv.bounds
+        g23mod.Rv = self.Rv.value
 
         # create the extinguished sed
         ext_sed = {}


### PR DESCRIPTION
For sightlines with very high or low Rv, we need to extend the Rv bounds accordingly. This commit sets the Rv range in G23 to the user defined Rv bounds, allowing for wider Rv bounds than the defaults set in dust_extinction. 