### PR TITLE
Fix bugs when normalizing by A(55) or E(44-55)

### DIFF
--- a/measure_extinction/extdata.py
+++ b/measure_extinction/extdata.py
@@ -757,7 +757,11 @@ class ExtData:
         -------
         Updates self.(exts, uncs)
         """
-        if self.type_rel_band != "V":
+        if (
+            (self.type_rel_band != "V")
+            and (self.type_rel_band != 0.55 * u.micron)
+            and (self.type_rel_band != 5500.0 * u.angstrom)
+        ):
             warnings.warn(
                 "attempt to normalize a non E(lambda-V) curve with E(B-V)", UserWarning
             )
@@ -1258,6 +1262,8 @@ class ExtData:
         self.type_rel_band = pheader.get("EXTBAND")
         if self.type_rel_band is None:
             self.type_rel_band = "V"
+        if ("Angstrom" in self.type_rel_band) or ("micron" in self.type_rel_band):
+            self.type_rel_band = u.Quantity(self.type_rel_band)
         self.red_file = pheader.get("R_FILE")
         self.comp_file = pheader.get("C_FILE")
 

--- a/measure_extinction/plotting/plot_ext.py
+++ b/measure_extinction/plotting/plot_ext.py
@@ -198,9 +198,11 @@ def plot_extmodels(extdata, alax=False, wavenum=False):
         curve = G23(Rv=cRv)
         if alax:
             if extdata.type_rel_band != "V":
-                emod = G23(cRv)
-                (indx,) = np.where(extdata.type_rel_band == extdata.names["BAND"])
-                axav = emod(extdata.waves["BAND"][indx[0]])
+                if isinstance(extdata.type_rel_band, str):  # reference photometric band
+                    (indx,) = np.where(extdata.type_rel_band == extdata.names["BAND"])
+                    axav = curve(extdata.waves["BAND"][indx[0]])
+                else:  # reference spectroscopic wavelength
+                    axav = curve(extdata.type_rel_band)
             else:
                 axav = 1.0
             y = curve(x) / axav


### PR DESCRIPTION
Makes sure the rel_band is either a string (for a band) or a astropy quantity (for a wavelength).  This allows the trans functions to do the right thing based on the header keywords.

Note that the header keywords still say AV = XX and EBV = XX even when it really is A55 and E4455.  Would be good to do a bit of an overhaul to have the header keywords more generic (e.g., AX and EYX) and have the X and Y  given in rel_band and a new keyword rel_band2 (or something like that).  This requires a bunch of changes to the code.  An issue opened for this #157.