### PR TITLE
Add WFC3 grism mocking for models

### DIFF
--- a/measure_extinction/extdata.py
+++ b/measure_extinction/extdata.py
@@ -1215,7 +1215,7 @@ class ExtData:
             hdulist.append(tbhdu)
 
         # save parameters passed as tables in extensions or is a member variable
-        if self.fit_params is not None:
+        if fit_params is None and self.fit_params is not None:
             fit_params = self.fit_params
 
         if fit_params is not None:

--- a/measure_extinction/merge_obsspec.py
+++ b/measure_extinction/merge_obsspec.py
@@ -7,10 +7,6 @@ __all__ = [
     "merge_iue_obsspec",
     "merge_stis_obsspec",
     "merge_spex_obsspec",
-    "merge_nircam_ss_obsspec",
-    "merge_irs_obsspec",
-    "merge_miri_lrs_obsspec",
-    "merge_miri_ifu_obsspec",
 ]
 
 fluxunit = u.erg / (u.s * u.cm * u.cm * u.angstrom)

--- a/measure_extinction/merge_obsspec.py
+++ b/measure_extinction/merge_obsspec.py
@@ -17,7 +17,16 @@ fluxunit = u.erg / (u.s * u.cm * u.cm * u.angstrom)
 
 
 # define the basic info for each type of spectra
-obsspecinfo = {"wfc3_g102": (210, (0.8, 1.15)), "wfc3_g141": (130, (1.075, 1.70))}
+#   info for each entry is (resolution, wavelength_range)
+obsspecinfo = {
+    "wfc3_g102": (210, [0.8, 1.15] * u.micron),
+    "wfc3_g141": (130, [1.075, 1.70] * u.micron),
+    "niriss_soss": (700, [0.85, 2.75] * u.micron),
+    "nircam_ss": (1600, [2.35, 5.55] * u.micron),
+    "irs": (150, [5.0, 40.0] * u.micron),
+    "miri_lrs": (160, [5.0, 13.0] * u.micron),
+    "miri_ifu": (3000, [4.8, 29.0] * u.micron),
+}
 
 
 def _wavegrid(resolution, wave_range):
@@ -316,146 +325,4 @@ def merge_iue_obsspec(obstables, output_resolution=1000):
         wave_range,
         output_resolution=output_resolution,
     )
-    return otable
-
-
-def merge_irs_obsspec(obstables, output_resolution=150):
-    """
-    Merge one or more Spitzer IRS 1D spectra into a single spectrum
-    on a uniform wavelength scale
-
-    Parameters
-    ----------
-    obstables : list of astropy Table objects
-        list of tables containing the observed IRS spectra
-        usually the result of reading tables
-
-    output_resolution : float
-        output resolution of spectra
-        input spectrum assumed to be at the observed resolution
-
-    Returns
-    -------
-    output_table : astropy Table object
-        merged spectrum
-    """
-    wave_range = [5.0, 40.0] * u.micron
-    otable = merge_gen_obsspec(
-        obstables,
-        wave_range,
-        output_resolution=output_resolution,
-    )
-    return otable
-
-
-def merge_niriss_soss_obsspec(obstables, output_resolution=700):
-    """
-    Merge one or more NIRCam slitless 1D spectra into a single spectrum
-    on a uniform wavelength scale
-
-    Parameters
-    ----------
-    obstables : list of astropy Table objects
-        list of tables containing the observed IRS spectra
-        usually the result of reading tables
-
-    output_resolution : float
-        output resolution of spectra
-        input spectrum assumed to be at the observed resolution
-
-    Returns
-    -------
-    output_table : astropy Table object
-        merged spectrum
-    """
-    wave_range = [0.85, 2.75] * u.micron
-    otable = merge_gen_obsspec(
-        obstables, wave_range, output_resolution=output_resolution
-    )
-    return otable
-
-
-def merge_nircam_ss_obsspec(obstables, output_resolution=1600):
-    """
-    Merge one or more NIRCam slitless 1D spectra into a single spectrum
-    on a uniform wavelength scale
-
-    Parameters
-    ----------
-    obstables : list of astropy Table objects
-        list of tables containing the observed IRS spectra
-        usually the result of reading tables
-
-    output_resolution : float
-        output resolution of spectra
-        input spectrum assumed to be at the observed resolution
-
-    Returns
-    -------
-    output_table : astropy Table object
-        merged spectrum
-    """
-    wave_range = [2.35, 5.55] * u.micron
-    otable = merge_gen_obsspec(
-        obstables, wave_range, output_resolution=output_resolution
-    )
-    return otable
-
-
-def merge_miri_lrs_obsspec(obstables, output_resolution=160):
-    """
-    Merge one or more MIRI LRS spectra into a single spectrum
-    on a uniform wavelength scale
-
-    Parameters
-    ----------
-    obstables : list of astropy Table objects
-        list of tables containing the observed IRS spectra
-        usually the result of reading tables
-
-    output_resolution : float
-        output resolution of spectra
-        input spectrum assumed to be at the observed resolution
-
-    Returns
-    -------
-    output_table : astropy Table object
-        merged spectrum
-    """
-    wave_range = [5.0, 13.0] * u.micron
-    otable = merge_gen_obsspec(
-        obstables,
-        wave_range,
-        output_resolution=output_resolution,
-    )
-    return otable
-
-
-def merge_miri_ifu_obsspec(obstables, output_resolution=3000):
-    """
-    Merge one or more MIRI IFU 1D spectra into a single spectrum
-    on a uniform wavelength scale
-
-    Parameters
-    ----------
-    obstables : list of astropy Table objects
-        list of tables containing the observed IRS spectra
-        usually the result of reading tables
-
-    output_resolution : float
-        output resolution of spectra
-        input spectrum assumed to be at the observed resolution
-
-    Returns
-    -------
-    output_table : astropy Table object
-        merged spectrum
-    """
-    wave_range = [4.8, 29.0] * u.micron
-    otable = merge_gen_obsspec(
-        obstables,
-        wave_range,
-        output_resolution=output_resolution,
-    )
-
     return otable

--- a/measure_extinction/merge_obsspec.py
+++ b/measure_extinction/merge_obsspec.py
@@ -3,6 +3,7 @@ from astropy.table import Table, Column
 import astropy.units as u
 
 __all__ = [
+    "merge_gen_obsspec",
     "merge_iue_obsspec",
     "merge_stis_obsspec",
     "merge_spex_obsspec",
@@ -13,6 +14,10 @@ __all__ = [
 ]
 
 fluxunit = u.erg / (u.s * u.cm * u.cm * u.angstrom)
+
+
+# define the basic info for each type of spectra
+obsspecinfo = {"wfc3_g102": (210, (0.8, 1.15)), "wfc3_g141": (130, (1.075, 1.70))}
 
 
 def _wavegrid(resolution, wave_range):
@@ -307,7 +312,9 @@ def merge_iue_obsspec(obstables, output_resolution=1000):
     wave_range = [1000.0, 3400.0] * u.angstrom
 
     otable = merge_gen_obsspec(
-        obstables, wave_range, output_resolution=output_resolution,
+        obstables,
+        wave_range,
+        output_resolution=output_resolution,
     )
     return otable
 
@@ -334,7 +341,9 @@ def merge_irs_obsspec(obstables, output_resolution=150):
     """
     wave_range = [5.0, 40.0] * u.micron
     otable = merge_gen_obsspec(
-        obstables, wave_range, output_resolution=output_resolution,
+        obstables,
+        wave_range,
+        output_resolution=output_resolution,
     )
     return otable
 
@@ -415,7 +424,9 @@ def merge_miri_lrs_obsspec(obstables, output_resolution=160):
     """
     wave_range = [5.0, 13.0] * u.micron
     otable = merge_gen_obsspec(
-        obstables, wave_range, output_resolution=output_resolution,
+        obstables,
+        wave_range,
+        output_resolution=output_resolution,
     )
     return otable
 
@@ -442,7 +453,9 @@ def merge_miri_ifu_obsspec(obstables, output_resolution=3000):
     """
     wave_range = [4.8, 29.0] * u.micron
     otable = merge_gen_obsspec(
-        obstables, wave_range, output_resolution=output_resolution,
+        obstables,
+        wave_range,
+        output_resolution=output_resolution,
     )
 
     return otable

--- a/measure_extinction/model.py
+++ b/measure_extinction/model.py
@@ -94,7 +94,7 @@ class MEModel(object):
     #  bad regions are defined as those were we know the models do not work
     #  or the data is bad
     exclude_regions = [
-        [8.23 - 0.1, 8.23 + 0.1],  # geocoronal line
+        [8.23 - 0.05, 8.23 + 0.05],  # geocoronal line
         [8.7, 10.0],  # bad data from STIS
         [3.55, 3.6],
         [3.80, 3.90],

--- a/measure_extinction/model.py
+++ b/measure_extinction/model.py
@@ -1030,6 +1030,8 @@ class MEModel(object):
         ax = axes[0]
         yrange = [100.0, -100.0]
         yrange_lya = [100.0, -100.0]
+
+        first_pass = True
         for cspec in obsdata.data.keys():
             if cspec == "BAND":
                 ptype = "o"
@@ -1049,18 +1051,25 @@ class MEModel(object):
             multlam = self.norm.value * np.power(cwaves, 4.0)
             multval = multlam * nvals
 
+            if first_pass:
+                plabs = ["Obs", "Star", "w/ Foreground", "w/ Dust Ext", "w/ Dust+Gas Ext"]
+            else:
+                plabs = [None, None, None, None, None]
+
             for cax in tax:
                 if self.fore_Av.value > 0.0:
                     cax.plot(
                         cwaves, modsed_nofore[cspec] * multlam, "c" + ptype, alpha=0.2
                     )
-                    cax.plot(cwaves, modsed_nofore[cspec] * multval, "c" + ptype)
+                    cax.plot(cwaves, modsed_nofore[cspec] * multval, "c" + ptype, label=plabs[1])
+                    cax.plot(cwaves, modsed[cspec] * multval, "b" + ptype, label=plabs[2])
+                else:
+                    cax.plot(cwaves, modsed[cspec] * multval, "b" + ptype, label=plabs[1])
                 cax.plot(cwaves, modsed[cspec] * multlam, "b" + ptype, alpha=0.2)
-                cax.plot(cwaves, modsed[cspec] * multval, "b" + ptype)
                 cax.plot(cwaves, ext_modsed[cspec] * multlam, "g" + ptype, alpha=0.2)
-                cax.plot(cwaves, ext_modsed[cspec] * multval, "g" + ptype)
+                cax.plot(cwaves, ext_modsed[cspec] * multval, "g" + ptype, label=plabs[3])
                 cax.plot(cwaves, hi_ext_modsed[cspec] * multlam, "r" + ptype, alpha=0.2)
-                cax.plot(cwaves, hi_ext_modsed[cspec] * multval, "r" + ptype)
+                cax.plot(cwaves, hi_ext_modsed[cspec] * multval, "r" + ptype, label=plabs[4])
 
                 gvals = obsdata.data[cspec].fluxes > 0.0
                 cax.plot(
@@ -1068,7 +1077,6 @@ class MEModel(object):
                     obsdata.data[cspec].fluxes[gvals]
                     * np.power(obsdata.data[cspec].waves[gvals], 4.0),
                     "k" + ptype,
-                    label="data",
                     alpha=0.2,
                 )
                 cax.plot(
@@ -1077,9 +1085,10 @@ class MEModel(object):
                     * np.power(obsdata.data[cspec].waves, 4.0)
                     * nvals,
                     "k" + ptype,
-                    label="data",
+                    label=plabs[0],
                     alpha=0.75,
                 )
+                first_pass = False
 
             # plot the residuals
             gvals = hi_ext_modsed[cspec] > 0.0
@@ -1136,6 +1145,8 @@ class MEModel(object):
                     yrange_lya[0] = np.min([tyrange[0], yrange_lya[0]])
                     yrange_lya[1] = np.max([tyrange[1], yrange_lya[1]])
 
+        tax[0].legend(ncol=2, fontsize=0.7 * fontsize)
+
         ax.set_xscale("log")
         axes[1].set_xscale("log")
         ax.set_yscale("log")
@@ -1151,6 +1162,7 @@ class MEModel(object):
             axes[3].set_xlim(0.115, 0.13)
             axes[3].set_ylim(-1.0 * resid_range, resid_range)
             axes[3].axhline(0.0, color="k", linestyle=":")
+            axes[3].set_xlabel(r"$\lambda$ [$\mu m$]", fontsize=1.3 * fontsize)
 
         axes[1].set_xlabel(r"$\lambda$ [$\mu m$]", fontsize=1.3 * fontsize)
         ax.set_ylabel(r"$\lambda^4 F(\lambda)$ [RJ units]", fontsize=1.3 * fontsize)
@@ -1169,17 +1181,18 @@ class MEModel(object):
                 else:
                     ptxt = f"{cname} = {param.value:.3f}"
                 ax.text(
-                    0.7,
-                    0.5 - k * 0.04,
+                    0.65,
+                    0.7 - k * 0.0325,
                     ptxt,
                     horizontalalignment="left",
                     verticalalignment="center",
                     transform=ax.transAxes,
-                    fontsize=0.8 * fontsize,
+                    fontsize=0.7 * fontsize,
                 )
                 k += 1
 
-        ax.text(0.1, 0.9, obsdata.file, transform=ax.transAxes, fontsize=fontsize)
+        # ax.text(0.1, 0.9, obsdata.file, transform=ax.transAxes, fontsize=fontsize)
+        ax.set_title((obsdata.file).replace(".dat", ""), fontsize=fontsize)
 
         fig.tight_layout()
 

--- a/measure_extinction/plotting/plot_model.py
+++ b/measure_extinction/plotting/plot_model.py
@@ -18,9 +18,7 @@ def main():
         choices=["chains", "corner", "bestfit"],
         default="bestfit",
     )
-    parser.add_argument(
-        "--residrange", help="residual range in percentage", default=50.0, type=float
-    )
+    parser.add_argument("--residrange", help="residual range in percentage", default=50.0, type=float)
     parser.add_argument("--burnfrac", help="burn fraction", default=0.5, type=float)
     parser.add_argument(
         "--obspath",
@@ -119,9 +117,7 @@ def main():
         fig = memod.plot_sampler_corner(flat_samples)
         save_str = "_mefit_corner"
     else:
-        fig = memod.plot(
-            reddened_star, modinfo, lyaplot=True, resid_range=args.residrange
-        )
+        fig = memod.plot(reddened_star, modinfo, lyaplot=True, resid_range=args.residrange)
         save_str = "_mefit_mcmc"
 
     # plot or save to a file
@@ -131,7 +127,6 @@ def main():
         fig.savefig(f"{args.starname}{save_str}.pdf")
     else:
         plt.show()
-
 
 if __name__ == "__main__":
     main()

--- a/measure_extinction/plotting/plot_model.py
+++ b/measure_extinction/plotting/plot_model.py
@@ -18,7 +18,9 @@ def main():
         choices=["chains", "corner", "bestfit"],
         default="bestfit",
     )
-    parser.add_argument("--residrange", help="residual range in percentage", default=50.0, type=float)
+    parser.add_argument(
+        "--residrange", help="residual range in percentage", default=50.0, type=float
+    )
     parser.add_argument("--burnfrac", help="burn fraction", default=0.5, type=float)
     parser.add_argument(
         "--obspath",
@@ -117,7 +119,9 @@ def main():
         fig = memod.plot_sampler_corner(flat_samples)
         save_str = "_mefit_corner"
     else:
-        fig = memod.plot(reddened_star, modinfo, lyaplot=True, resid_range=args.residrange)
+        fig = memod.plot(
+            reddened_star, modinfo, lyaplot=True, resid_range=args.residrange
+        )
         save_str = "_mefit_mcmc"
 
     # plot or save to a file
@@ -127,6 +131,7 @@ def main():
         fig.savefig(f"{args.starname}{save_str}.pdf")
     else:
         plt.show()
+
 
 if __name__ == "__main__":
     main()

--- a/measure_extinction/plotting/plot_model.py
+++ b/measure_extinction/plotting/plot_model.py
@@ -18,6 +18,7 @@ def main():
         choices=["chains", "corner", "bestfit"],
         default="bestfit",
     )
+    parser.add_argument("--residrange", help="residual range in percentage", default=50.0, type=float)
     parser.add_argument("--burnfrac", help="burn fraction", default=0.5, type=float)
     parser.add_argument(
         "--obspath",
@@ -30,6 +31,8 @@ def main():
     parser.add_argument(
         "--bands", help="only use these observed bands", nargs="+", default=None
     )
+    parser.add_argument("--png", help="save figure as a png file", action="store_true")
+    parser.add_argument("--pdf", help="save figure as a pdf file", action="store_true")
     args = parser.parse_args()
 
     # base filename
@@ -108,13 +111,22 @@ def main():
     memod.pprint_parameters()
 
     if args.plttype == "chains":
-        memod.plot_sampler_chains(reader)
+        fig = memod.plot_sampler_chains(reader)
+        save_str = "_mefit_chains"
     elif args.plttype == "corner":
-        memod.plot_sampler_corner(flat_samples)
+        fig = memod.plot_sampler_corner(flat_samples)
+        save_str = "_mefit_corner"
     else:
-        memod.plot(reddened_star, modinfo)
-    plt.show()
+        fig = memod.plot(reddened_star, modinfo, lyaplot=True, resid_range=args.residrange)
+        save_str = "_mefit_mcmc"
 
+    # plot or save to a file
+    if args.png:
+        fig.savefig(f"{args.starname}{save_str}.png")
+    elif args.pdf:
+        fig.savefig(f"{args.starname}{save_str}.pdf")
+    else:
+        plt.show()
 
 if __name__ == "__main__":
     main()

--- a/measure_extinction/tests/test_merge_obsspec.py
+++ b/measure_extinction/tests/test_merge_obsspec.py
@@ -52,8 +52,7 @@ def test_iue():
     _check_genmerge(wave_range, resolution, merge_iue_obsspec, iue=True)
 
 
-# only need to test one of the "generic" merges as all the 
-# rest work the same
+# only need to test one of the "generic" merges as all the rest work the same
 def test_irs():
     wave_range = [5.0, 40.0] * u.micron
     resolution = 150.0

--- a/measure_extinction/tests/test_merge_obsspec.py
+++ b/measure_extinction/tests/test_merge_obsspec.py
@@ -6,18 +6,14 @@ from measure_extinction.merge_obsspec import (
     fluxunit,
     _wavegrid,
     merge_iue_obsspec,
-    merge_irs_obsspec,
-    merge_niriss_soss_obsspec,
-    merge_nircam_ss_obsspec,
-    merge_miri_lrs_obsspec,
-    merge_miri_ifu_obsspec,
+    merge_gen_obsspec,
 )
 
 # still need to add merging of STIS spectroscopy
 #  more complicated due to UV/optical options
 
 
-def _check_genmerge(wave_range, resolution, mergefunc):
+def _check_genmerge(wave_range, resolution, mergefunc, iue=False):
 
     wave1_info = _wavegrid(resolution, wave_range.value)
     wave1 = wave1_info[0] * wave_range.unit
@@ -37,7 +33,10 @@ def _check_genmerge(wave_range, resolution, mergefunc):
     itable2["NPTS"] = np.full(nwaves, 1)
 
     # merge into standard format
-    otable = mergefunc([itable1, itable2])
+    if iue:
+        otable = mergefunc([itable1, itable2])
+    else:
+        otable = mergefunc([itable1, itable2], wave_range, resolution)
 
     # check standard format
     for ckey in ["WAVELENGTH", "FLUX", "SIGMA", "NPTS"]:
@@ -50,34 +49,12 @@ def _check_genmerge(wave_range, resolution, mergefunc):
 def test_iue():
     wave_range = [1000.0, 3400.0] * u.angstrom
     resolution = 1000.0
-    _check_genmerge(wave_range, resolution, merge_iue_obsspec)
+    _check_genmerge(wave_range, resolution, merge_iue_obsspec, iue=True)
 
 
+# only need to test one of the "generic" merges as all the 
+# rest work the same
 def test_irs():
     wave_range = [5.0, 40.0] * u.micron
     resolution = 150.0
-    _check_genmerge(wave_range, resolution, merge_irs_obsspec)
-
-
-def test_niriss_soss():
-    wave_range = [0.85, 2.75] * u.micron
-    resolution = 700.0
-    _check_genmerge(wave_range, resolution, merge_niriss_soss_obsspec)
-
-
-def test_nircam_ss():
-    wave_range = [2.35, 5.55] * u.micron
-    resolution = 1600.0
-    _check_genmerge(wave_range, resolution, merge_nircam_ss_obsspec)
-
-
-def test_miri_lrs():
-    wave_range = [4.0, 15.0] * u.micron
-    resolution = 160.0
-    _check_genmerge(wave_range, resolution, merge_miri_lrs_obsspec)
-
-
-def test_miri_mrs():
-    wave_range = [4.5, 32.0] * u.micron
-    resolution = 4000.0
-    _check_genmerge(wave_range, resolution, merge_miri_ifu_obsspec)
+    _check_genmerge(wave_range, resolution, merge_gen_obsspec)

--- a/measure_extinction/utils/make_obsdata_from_model.py
+++ b/measure_extinction/utils/make_obsdata_from_model.py
@@ -16,11 +16,6 @@ from measure_extinction.merge_obsspec import (
     merge_gen_obsspec,
     merge_iue_obsspec,
     merge_stis_obsspec,
-    merge_irs_obsspec,
-    merge_niriss_soss_obsspec,
-    merge_nircam_ss_obsspec,
-    merge_miri_lrs_obsspec,
-    merge_miri_ifu_obsspec,
 )
 from measure_extinction.utils.mock_spectra_data import mock_stis_data
 
@@ -300,7 +295,8 @@ def make_obsdata_from_model(
     if specs == "all":
         # fmt: off
         specs = ["MODEL_FULL_LOWRES", "MODEL_FULL", "IUE", "STIS", "IRS",
-                 "NIRISS_SOSS", "NIRCam_SS", "MIRI_LRS", "MIRI_MRS"]
+                 "WFC3_G102", "WFC3_G141",
+                 "NIRISS_SOSS", "NIRCAM_SS", "MIRI_LRS", "MIRI_IFU"]
         # fmt: on
 
     # rebin to R=10000 for speed
@@ -309,6 +305,38 @@ def make_obsdata_from_model(
     wave_rebin, flux_rebin, npts_rebin = rebin_spectrum(
         mwave.value, mflux.value, rbres, [912.0, 310000.0]
     )
+
+    # compute photometry
+    john_bands = ["U", "B", "V", "R", "I", "J", "H", "K"]
+    john_fnames = [f"John{cband}.dat" for cband in john_bands]
+    hst_bands = [
+        "HST_WFC3_UVIS1_F275W",
+        "HST_WFC3_UVIS1_F336W",
+        "HST_WFC3_UVIS1_F475W",
+        "HST_WFC3_UVIS1_F625W",
+        "HST_WFC3_UVIS1_F775W",
+        "HST_WFC3_UVIS1_F814W",
+        "HST_WFC3_IR_F110W",
+        "HST_WFC3_IR_F160W",
+        "HST_ACS_WFC1_F475W",
+        "HST_ACS_WFC1_F814W",
+        "HST_WFPC2_4_F170W",
+        "HST_WFPC2_4_F255W",
+        "HST_WFPC2_4_F336W",
+        "HST_WFPC2_4_F439W",
+        "HST_WFPC2_4_F555W",
+        "HST_WFPC2_4_F814W",
+    ]
+    hst_fnames = [""]
+    # fmt: off
+    ir_bands = ['IRAC1', 'IRAC2', 'IRAC3', 'IRAC4', 'IRS15', 'MIPS24',
+                'WISE1', 'WISE2', 'WISE3', 'WISE4']
+    # fmt: on
+    ir_fnames = [f"{cband}.dat" for cband in ir_bands]
+    bands = john_bands + ir_bands + hst_bands
+    band_fnames = john_fnames + ir_fnames + hst_fnames
+
+    bandinfo = get_phot(wave_rebin, flux_rebin, bands, band_fnames)
 
     # dictionary to saye names of spectroscopic filenames
     specinfo = {}
@@ -385,182 +413,6 @@ def make_obsdata_from_model(
     specinfo["STIS"] = stis_uv_file
     specinfo["STIS_Opt"] = stis_opt_file
 
-    lrs_file = "%s_irs.fits" % (output_filebase)
-    if (specs is not None) and ("IRS" in specs):
-        # Spitzer IRS mock observation
-        # Resolution approximately 100
-        lrs_fwhm_pix = rbres / 100.0
-        g = Gaussian1DKernel(stddev=lrs_fwhm_pix / 2.355)
-        # Convolve data
-        nflux = convolve(otable["FLUX"].data, g)
-
-        lrs_table = QTable()
-        lrs_table["WAVELENGTH"] = otable["WAVELENGTH"]
-        lrs_table["FLUX"] = nflux * fluxunit
-        lrs_table["NPTS"] = otable["NPTS"]
-        lrs_table["ERROR"] = Column(np.full((len(lrs_table)), 1.0)) * fluxunit
-
-        rb_lrs = merge_irs_obsspec([lrs_table])
-        rb_lrs["SIGMA"] = rb_lrs["FLUX"] * 0.0
-        rb_lrs.write("%s/Models/%s" % (output_path, lrs_file), overwrite=True)
-
-    specinfo["IRS"] = lrs_file
-
-    nrs_file = "%s_niriss_soss.fits" % (output_filebase)
-    if (specs is not None) and ("NIRISS_SOSS" in specs):
-        # Webb NIRISS SOSS spectra mock observation
-        # Resolution approximately 700
-        nrc_fwhm_pix = rbres / 700
-        g = Gaussian1DKernel(stddev=nrc_fwhm_pix / 2.355)
-        # Convolve data
-        nflux = convolve(otable["FLUX"].data, g)
-
-        niriss_table = QTable()
-        niriss_table["WAVELENGTH"] = otable["WAVELENGTH"]
-        niriss_table["FLUX"] = nflux * fluxunit
-        niriss_table["NPTS"] = otable["NPTS"]
-        niriss_table["ERROR"] = Column(np.full((len(niriss_table)), 1.0)) * fluxunit
-
-        rb_niriss = merge_niriss_soss_obsspec([niriss_table])
-        rb_niriss["SIGMA"] = rb_niriss["FLUX"] * 0.0
-        rb_niriss.write("%s/Models/%s" % (output_path, nrs_file), overwrite=True)
-
-    specinfo["NIRISS_SOSS"] = nrs_file
-
-    nrc_file = "%s_nircam_ss.fits" % (output_filebase)
-    if (specs is not None) and ("NIRCam_SS" in specs):
-        # Webb NIRCam spectra mock observation
-        # Resolution approximately 1600
-        nrc_fwhm_pix = rbres / 1600.0
-        g = Gaussian1DKernel(stddev=nrc_fwhm_pix / 2.355)
-        # Convolve data
-        nflux = convolve(otable["FLUX"].data, g)
-
-        nrc_table = QTable()
-        nrc_table["WAVELENGTH"] = otable["WAVELENGTH"]
-        nrc_table["FLUX"] = nflux * fluxunit
-        nrc_table["NPTS"] = otable["NPTS"]
-        nrc_table["ERROR"] = Column(np.full((len(nrc_table)), 1.0)) * fluxunit
-
-        rb_nrc = merge_nircam_ss_obsspec([nrc_table])
-        rb_nrc["SIGMA"] = rb_nrc["FLUX"] * 0.0
-        rb_nrc.write("%s/Models/%s" % (output_path, nrc_file), overwrite=True)
-
-    specinfo["NIRCam_SS"] = nrc_file
-
-    miri_lrs_file = "%s_miri_lrs.fits" % (output_filebase)
-    if (specs is not None) and ("MIRI_LRS" in specs):
-        # MIRI LRS mock observation
-        # Resolution approximately 40-160
-        miri_lrs_fwhm_pix = rbres / 160.0
-        g = Gaussian1DKernel(stddev=miri_lrs_fwhm_pix / 2.355)
-        # Convolve data
-        nflux = convolve(otable["FLUX"].data, g)
-
-        miri_lrs_table = QTable()
-        miri_lrs_table["WAVELENGTH"] = otable["WAVELENGTH"]
-        miri_lrs_table["FLUX"] = nflux * fluxunit
-        miri_lrs_table["NPTS"] = otable["NPTS"]
-        miri_lrs_table["ERROR"] = Column(np.full((len(miri_lrs_table)), 1.0)) * fluxunit
-
-        rb_miri_lrs = merge_miri_lrs_obsspec([miri_lrs_table])
-        rb_miri_lrs["SIGMA"] = rb_miri_lrs["FLUX"] * 0.0
-        rb_miri_lrs.write("%s/Models/%s" % (output_path, miri_lrs_file), overwrite=True)
-
-    specinfo["MIRI_LRS"] = miri_lrs_file
-
-    mrs_file = "%s_miri_ifu.fits" % (output_filebase)
-    if (specs is not None) and ("MIRI_MRS" in specs):
-        # Webb MIRI IFU mock observation
-        # Resolution approximately 3000
-        mrs_fwhm_pix = rbres / 3000.0
-        g = Gaussian1DKernel(stddev=mrs_fwhm_pix / 2.355)
-        # Convolve data
-        nflux = convolve(otable["FLUX"].data, g)
-
-        mrs_table = QTable()
-        mrs_table["WAVELENGTH"] = otable["WAVELENGTH"]
-        mrs_table["FLUX"] = nflux * fluxunit
-        mrs_table["NPTS"] = otable["NPTS"]
-        mrs_table["ERROR"] = Column(np.full((len(mrs_table)), 1.0)) * fluxunit
-
-        rb_mrs = merge_miri_ifu_obsspec([mrs_table])
-
-        rb_mrs["SIGMA"] = rb_mrs["FLUX"] * 0.0
-        rb_mrs.write("%s/Models/%s" % (output_path, mrs_file), overwrite=True)
-
-    specinfo["MIRI_IFU"] = mrs_file
-
-    for cspec in obsspecinfo.keys():
-        cres = obsspecinfo[cspec][0]
-        ofile = f"{output_filebase}_{cspec}.fits"
-        if (specs is not None) and (cspec in specs):
-            fwhm_pix = rbres / cres
-            g = Gaussian1DKernel(stddev=fwhm_pix / 2.355)
-            nflux = convolve(otable["FLUX"].data, g)
-
-            otable = QTable()
-            otable["WAVELENGTH"] = otable["WAVELENGTH"]
-            otable["FLUX"] = nflux * fluxunit
-            otable["NPTS"] = otable["NPTS"]
-            otable["ERROR"] = Column(np.full((len(otable)), 1.0)) * fluxunit
-
-            rb_info = merge_gen_obsspec([otable], obsspecinfo[cspec][1], output_resoluttion=cres)
-
-            rb_info["SIGMA"] = rb_info["FLUX"] * 0.0
-            rb_info.write(f"{output_path}/Models/{ofile}", overwrite=True)
-
-        specinfo[cspec.upper()] = ofile
-
-    # compute photometry
-    # band_path = "%s/Band_RespCurves/" % output_path
-    john_bands = ["U", "B", "V", "R", "I", "J", "H", "K"]
-    john_fnames = [f"John{cband}.dat" for cband in john_bands]
-    hst_bands = [
-        "HST_WFC3_UVIS1_F275W",
-        "HST_WFC3_UVIS1_F336W",
-        "HST_WFC3_UVIS1_F475W",
-        "HST_WFC3_UVIS1_F625W",
-        "HST_WFC3_UVIS1_F775W",
-        "HST_WFC3_UVIS1_F814W",
-        "HST_WFC3_IR_F110W",
-        "HST_WFC3_IR_F160W",
-        "HST_ACS_WFC1_F475W",
-        "HST_ACS_WFC1_F814W",
-        "HST_WFPC2_4_F170W",
-        "HST_WFPC2_4_F255W",
-        "HST_WFPC2_4_F336W",
-        "HST_WFPC2_4_F439W",
-        "HST_WFPC2_4_F555W",
-        "HST_WFPC2_4_F814W",
-    ]
-    hst_fnames = [""]
-    # fmt: off
-    ir_bands = ['IRAC1', 'IRAC2', 'IRAC3', 'IRAC4', 'IRS15', 'MIPS24',
-                'WISE1', 'WISE2', 'WISE3', 'WISE4']
-    # fmt: on
-    ir_fnames = [f"{cband}.dat" for cband in ir_bands]
-    bands = john_bands + ir_bands + hst_bands
-    band_fnames = john_fnames + ir_fnames + hst_fnames
-
-    bandinfo = get_phot(wave_rebin, flux_rebin, bands, band_fnames)
-
-    # create the DAT file
-    dat_filename = "%s/Models/%s.dat" % (output_path, output_filebase)
-    header_info = [
-        "# obsdata created from %s model atmosphere" % model_type,
-        "# %s" % (output_filebase),
-        "# file created by make_obsdata_from_model.py",
-        "model_type = %s" % model_type,
-    ]
-    write_dat_file(
-        dat_filename,
-        bandinfo,
-        specinfo,
-        modelparams=model_params,
-        header_info=header_info,
-    )
-
     if show_plot:
         fig, ax = plt.subplots(figsize=(10, 8))
         ax.plot(wave_rebin * 1e-4, flux_rebin * 2.0, "b-")
@@ -586,40 +438,56 @@ def make_obsdata_from_model(
                 rb_iue["WAVELENGTH"][indxs].to(u.micron), rb_iue["FLUX"][indxs], "r-"
             )
 
-        if (specs is not None) and ("NIRCam_SS" in specs):
-            (indxs,) = np.where(rb_nrc["NPTS"] > 0)
-            ax.plot(
-                rb_nrc["WAVELENGTH"][indxs].to(u.micron), rb_nrc["FLUX"][indxs], "c-"
+    for cspec in obsspecinfo.keys():
+        print(cspec)
+        cres = obsspecinfo[cspec][0]
+        ofile = f"{output_filebase}_{cspec}.fits"
+        if (specs is not None) and (cspec.upper() in specs):
+            print("working on")
+            fwhm_pix = rbres / cres
+            g = Gaussian1DKernel(stddev=fwhm_pix / 2.355)
+            nflux = convolve(otable["FLUX"].data, g)
+
+            outtable = QTable()
+            outtable["WAVELENGTH"] = otable["WAVELENGTH"]
+            outtable["FLUX"] = nflux * fluxunit
+            outtable["NPTS"] = otable["NPTS"]
+            outtable["ERROR"] = Column(np.full((len(otable)), 1.0)) * fluxunit
+
+            rb_info = merge_gen_obsspec(
+                [outtable], obsspecinfo[cspec][1], output_resolution=cres
             )
 
-        if (specs is not None) and ("IRS" in specs):
-            (indxs,) = np.where(rb_lrs["NPTS"] > 0)
-            ax.plot(
-                rb_lrs["WAVELENGTH"][indxs].to(u.micron), rb_lrs["FLUX"][indxs], "r:"
-            )
+            rb_info["SIGMA"] = rb_info["FLUX"] * 0.0
+            rb_info.write(f"{output_path}/Models/{ofile}", overwrite=True)
 
-        if (specs is not None) and ("NIRISS_SOSS" in specs):
-            (indxs,) = np.where(rb_niriss["NPTS"] > 0)
-            ax.plot(
-                rb_niriss["WAVELENGTH"][indxs].to(u.micron),
-                rb_niriss["FLUX"][indxs],
-                "r-",
-            )
+            if show_plot:
+                gvals = rb_info["NPTS"] > 0
+                ax.plot(
+                    rb_info["WAVELENGTH"][gvals].to(u.micron),
+                    rb_info["FLUX"][gvals],
+                    "c-",
+                )
 
-        if (specs is not None) and ("MIRI_LRS" in specs):
-            (indxs,) = np.where(rb_miri_lrs["NPTS"] > 0)
-            ax.plot(
-                rb_miri_lrs["WAVELENGTH"][indxs].to(u.micron),
-                rb_miri_lrs["FLUX"][indxs],
-                "r--",
-            )
+        specinfo[cspec.upper()] = ofile
 
-        if (specs is not None) and ("MIRI_IFU" in specs):
-            (indxs,) = np.where(rb_mrs["NPTS"] > 0)
-            ax.plot(
-                rb_mrs["WAVELENGTH"][indxs].to(u.micron), rb_mrs["FLUX"][indxs], "g-"
-            )
+    # create the DAT file
+    dat_filename = "%s/Models/%s.dat" % (output_path, output_filebase)
+    header_info = [
+        "# obsdata created from %s model atmosphere" % model_type,
+        "# %s" % (output_filebase),
+        "# file created by make_obsdata_from_model.py",
+        "model_type = %s" % model_type,
+    ]
+    write_dat_file(
+        dat_filename,
+        bandinfo,
+        specinfo,
+        modelparams=model_params,
+        header_info=header_info,
+    )
 
+    if show_plot:
         ax.set_xscale("log")
         ax.set_yscale("log")
         plt.tight_layout()
@@ -644,5 +512,5 @@ if __name__ == "__main__":
         model_params=model_params,
         show_plot=True,
         # specs="all",
-        specs=["IUE", "MIRI_LRS"],
+        # specs=["WFC3_G102", "WFC3_G141"],
     )

--- a/measure_extinction/utils/merge_miri_ifu_spec.py
+++ b/measure_extinction/utils/merge_miri_ifu_spec.py
@@ -6,7 +6,7 @@ import matplotlib.pyplot as plt
 from astropy.table import QTable
 import astropy.units as u
 
-from measure_extinction.merge_obsspec import merge_miri_ifu_obsspec
+from measure_extinction.merge_obsspec import obsspecinfo, merge_gen_obsspec
 
 
 fluxunit = u.erg / (u.cm * u.cm * u.s * u.angstrom)
@@ -46,7 +46,8 @@ if __name__ == "__main__":
         cdata["NPTS"][cdata["FLUX"] == 0.0] = 0.0
         stable.append(cdata)
 
-    rb_mrs = merge_miri_ifu_obsspec(stable)
+    cres, crange = obsspecinfo["miri_ifu"]
+    rb_mrs = merge_gen_obsspec(stable, crange, cres)
     if args.outname:
         outname = args.outname
     else:

--- a/measure_extinction/utils/merge_nircam_spec.py
+++ b/measure_extinction/utils/merge_nircam_spec.py
@@ -6,7 +6,7 @@ import matplotlib.pyplot as plt
 from astropy.table import QTable
 import astropy.units as u
 
-from measure_extinction.merge_obsspec import merge_nircam_ss_obsspec
+from measure_extinction.merge_obsspec import obsspecinfo, merge_gen_obsspec
 
 
 fluxunit = u.erg / (u.cm * u.cm * u.s * u.angstrom)
@@ -46,7 +46,8 @@ if __name__ == "__main__":
         cdata["NPTS"][cdata["FLUX"] == 0.0] = 0.0
         stable.append(cdata)
 
-    rb_mrs = merge_nircam_ss_obsspec(stable)
+    cres, crange = obsspecinfo["nircam_ss"]
+    rb_mrs = merge_gen_obsspec(stable, crange, cres)
     if args.outname:
         outname = args.outname
     else:


### PR DESCRIPTION
Adding in the two grating for WFC3 IR grism data.  

As part of this, simplified the merging of spectra and generation of mock spectra from models.