### PR TITLE
Missing data/Band_RespCurves folder with pip install

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ docs =
     sphinx-astropy
 
 [options.package_data]
-measure_extinction = data/*.*, data/Spectra/*.fits
+measure_extinction = data/*.*, data/Spectra/*.fits, data/Band_RespCurves/*
 
 [tool:pytest]
 testpaths = "measure_extinction" "docs"


### PR DESCRIPTION
Fix missing data/Band_RespCurves folder with pip install (issue https://github.com/karllark/measure_extinction/issues/175)

Closes #175.